### PR TITLE
Match households with source_id, too

### DIFF
--- a/src/app/person-appearance/person-appearance-resolver.service.ts
+++ b/src/app/person-appearance/person-appearance-resolver.service.ts
@@ -26,8 +26,9 @@ export class PersonAppearanceResolverService implements Resolve<{pa:PersonAppear
                     "path": "person_appearance",
                     "query": {
                       "bool" : {
-                        "should": [
-                          { "match": { "person_appearance.hh_id": pa.hh_id } }
+                        "must": [
+                          { "match": { "person_appearance.hh_id": pa.hh_id } },
+                          { "match": { "person_appearance.source_id": pa.source_id } },
                         ]
                       }
                     }


### PR DESCRIPTION
A hh_id is unique only inside a source_id, so we matched too broadly!