### PR TITLE
Filter menu minor changes

### DIFF
--- a/src/app/search-result-list/search-result-list.component.html
+++ b/src/app/search-result-list/search-result-list.component.html
@@ -84,38 +84,36 @@
 </section>
 <section class="lls-container">
     <div class="lls-row">
-        <div class="lls-columns-6 lls-search-modifiers">
+        <div class="lls-columns-12 lls-columns-6--sm lls-columns-9--md lls-search-modifiers">
             <!-- Filtering -->
-            <div class="lls-columns-12 lls-columns-6--sm u-p-2">
-                <p>Filter resultater</p>
-                <button class="lls-btn lls-btn--outline lls-btn--link" (click)="openSidebar = true">
-                    <span>Kilder</span>
-                    <svg class="lls-icon lls-icon--right">
-                        <use [attr.href]="featherSpriteUrl + '#chevron-right'"></use>
+            <span class="lls-search-modifier-inputs__label">Filter resultater</span>
+            <button class="lls-btn lls-btn--outline lls-btn--link" (click)="openSidebar = true">
+                <span>Kilder</span>
+                <svg class="lls-icon lls-icon--right">
+                    <use [attr.href]="featherSpriteUrl + '#chevron-right'"></use>
+                </svg>
+            </button>
+            <lls-filter-sidebar
+                [(ngModel)]="sourceFilter"
+                [openSidebar]="openSidebar"
+                [featherIconPath]="config.featherIconPath"
+                [possibleYears]="possibleYears"
+                (closeSidebar)="closeSidebar($event)"
+                (removeFilter)="removeFilter($event)"
+            ></lls-filter-sidebar>
+            <div class="lls-results-filter__items">
+                <button
+                    *ngFor="let filterItem of sourceFilter; index as i;"
+                    class="lls-btn lls-btn--grey u-mr-2 u-mt-2 u-text-capitalize"
+                >
+                    <span>Folketælling {{ filterItem }}</span>
+                    <svg class="lls-icon lls-icon--right" (click)="removeFilter(filterItem)">
+                        <use [attr.href]="config.featherIconPath + '#x'"></use>
                     </svg>
                 </button>
-                <lls-filter-sidebar
-                    [(ngModel)]="sourceFilter"
-                    [openSidebar]="openSidebar"
-                    [featherIconPath]="config.featherIconPath"
-                    [possibleYears]="possibleYears"
-                    (closeSidebar)="closeSidebar($event)"
-                    (removeFilter)="removeFilter($event)"
-                ></lls-filter-sidebar>
-                <div class="lls-results-filter__items">
-                    <button
-                        *ngFor="let filterItem of sourceFilter; index as i;"
-                        class="lls-btn lls-btn--small lls-btn--grey u-mr-2 u-mt-2"
-                    >
-                        <span>{{ filterItem }}</span>
-                        <svg class="lls-icon lls-icon--right" (click)="removeFilter(filterItem)">
-                            <use [attr.href]="config.featherIconPath + '#x'"></use>
-                        </svg>
-                    </button>
-                </div>
             </div>
         </div>
-        <div class="lls-columns-12 lls-columns-6--sm lls-search-modifiers lls-search-modifiers--right">
+        <div class="lls-columns-12 lls-columns-6--sm lls-columns-3--md lls-search-modifiers lls-search-modifiers--right">
             <div class="lls-search-modifier-inputs lls-search-modifier-inputs">
                 <!--label class="lls-search-modifier-inputs__entry">
                     <span class="lls-search-modifier-inputs__label">Antal per side</span>

--- a/src/app/search-result-list/search-result-list.component.html
+++ b/src/app/search-result-list/search-result-list.component.html
@@ -106,7 +106,7 @@
                     *ngFor="let filterItem of sourceFilter; index as i;"
                     class="lls-btn lls-btn--grey u-mr-2 u-mt-2 u-text-capitalize"
                 >
-                    <span>Folketælling {{ filterItem }}</span>
+                    <span>FT {{ filterItem }}</span>
                     <svg class="lls-icon lls-icon--right" (click)="removeFilter(filterItem)">
                         <use [attr.href]="config.featherIconPath + '#x'"></use>
                     </svg>

--- a/src/assets/styling/boolean.scss
+++ b/src/assets/styling/boolean.scss
@@ -10,11 +10,16 @@ $booleanFontSize: 1.125rem;
   width: 100%;
   cursor: pointer;
   position: relative;
+  margin: 0.125rem 0;
 
   -moz-user-select: none;
   -webkit-user-select: none;
   -ms-user-select: none;
   user-select: none;
+
+  @media(min-width: $breakpointMd) {
+    margin: 0;
+  }
 
   .lls-icon {
     margin-top: 1px;

--- a/src/assets/styling/button.scss
+++ b/src/assets/styling/button.scss
@@ -90,7 +90,7 @@
 
 .lls-btn--outline {
   background-color: transparent;
-  border: 1px solid black;
+  border: 2px solid black;
   color: black;
   text-transform: none;
 

--- a/src/assets/styling/search-modifiers.scss
+++ b/src/assets/styling/search-modifiers.scss
@@ -10,12 +10,19 @@
   @media(min-width: $breakpointMd) {
     align-items: flex-end;
   }
+
+  @media(max-width: $breakpointSm) {
+    margin-top: 0rem;
+  }
 }
 
 .lls-search-modifier-inputs {
   display: flex;
-  justify-content: flex-end;
   width: 100%;
+
+  @media(min-width: $breakpointMd) {
+    align-items: flex-end;
+  }
 }
 
 .lls-search-modifier-inputs__entry {

--- a/src/assets/styling/search-modifiers.scss
+++ b/src/assets/styling/search-modifiers.scss
@@ -21,7 +21,7 @@
   width: 100%;
 
   @media(min-width: $breakpointMd) {
-    align-items: flex-end;
+    justify-content: flex-end;
   }
 }
 

--- a/src/assets/styling/search-modifiers.scss
+++ b/src/assets/styling/search-modifiers.scss
@@ -6,7 +6,10 @@
 .lls-search-modifiers--right {
   display: flex;
   flex-direction: column;
-  align-items: flex-end;
+
+  @media(min-width: $breakpointMd) {
+    align-items: flex-end;
+  }
 }
 
 .lls-search-modifier-inputs {
@@ -14,6 +17,7 @@
   justify-content: flex-end;
   width: 100%;
 }
+
 .lls-search-modifier-inputs__entry {
   margin-left: 0.25rem;
   margin-right: 0.25rem;
@@ -26,9 +30,11 @@
     margin-right: 0;
   }
 }
+
 .lls-search-modifier-inputs__entry--basis-200 {
   flex-basis: 200px;
 }
+
 .lls-search-modifier-inputs__label {
   display: block;
   margin-bottom: 0.25rem;


### PR DESCRIPTION
From Signe:
> Fire småting til looket.
>- Stregen omkring 'kilder' er tyndere end sorter-boksen. Jeg tænker de skal have samme tykkelse (som sorter efter).
>- Skriften Filtrer resultater - samme størrelse/højde som sorter efter (måske størrelsen er den samme, men det bare er højden, der snyder.
>- Skriften inde i de grå valgte filtre bokse må gerne være en smule større.
>- Jeg tror der skal stå FT 1850, FT 1880 osv. Bare med tanke for når der kommer flere kilder.

### Screenshot:
![image](https://user-images.githubusercontent.com/8166831/101051518-e2fbb000-3585-11eb-84c0-54f009238270.png)
