### PR TITLE
Sort by relevance

### DIFF
--- a/src/app/elasticsearch/elasticsearch.service.ts
+++ b/src/app/elasticsearch/elasticsearch.service.ts
@@ -221,12 +221,16 @@ export class ElasticsearchService {
     const body = {
       from: from,
       size: size,
+      indices_boost: [
+        { 'lifecourses': 1.05 },
+      ],
       query: {
         nested: {
           path: "person_appearance",
           query: {
             bool: { must },
           },
+          score_mode: "max",
         },
       },
       aggs: {

--- a/src/app/search-result-list/search-result-list.component.ts
+++ b/src/app/search-result-list/search-result-list.component.ts
@@ -38,7 +38,7 @@ export class SearchResultListComponent implements OnInit {
   };
 
   sourceFilter = [];
-  sortBy: string = "random";
+  sortBy: string = "relevance";
   sortByOptions = sortByOptions;
 
   sortAscending = true;
@@ -119,7 +119,7 @@ export class SearchResultListComponent implements OnInit {
       if(indices) {
         indices.split(",").forEach((index) => this.indices[index].value = true);
       }
-      this.sortBy = queryParamMap.get('sortBy') || "random";
+      this.sortBy = queryParamMap.get('sortBy') || "relevance";
       this.sortAscending = !(queryParamMap.get('sortOrder') === "desc");
       const sourceFilters = queryParamMap.get('sourceFilter');
       if(sourceFilters) {

--- a/src/app/search-result-list/search-result-resolver.service.ts
+++ b/src/app/search-result-list/search-result-resolver.service.ts
@@ -25,7 +25,7 @@ export class SearchResultResolverService implements Resolve<SearchResult> {
       size = 10;
     }
 
-    let sortBy: string = route.queryParamMap.get('sortBy') || "random";
+    let sortBy: string = route.queryParamMap.get('sortBy') || "relevance";
     let sortOrder: string = route.queryParamMap.get('sortOrder') === "desc" ? "desc" : "asc";
     const sourceFilterRaw = route.queryParamMap.get("sourceFilter");
     let sourceFilter: number[] = sourceFilterRaw ? sourceFilterRaw.split(",").filter(x => x).map((year) => parseInt(year)) : [];

--- a/src/app/search-term-values.ts
+++ b/src/app/search-term-values.ts
@@ -46,7 +46,6 @@ export const mapQueryShouldKey = {
 };
 
 export const sortValues = {
-  relevance: [ "_score" ],
   firstName: [ "first_names_sortable" ],
   lastName: [ "family_names_sortable" ],
   birthYear: [ "birth_year" ],
@@ -70,8 +69,7 @@ export const searchFieldPlaceholders = {
 export const possibleSearchQueryParams = Object.keys(searchFieldPlaceholders);
 
 export const sortByOptions = [
-  { label: "Tilfældig", value: "random" },
-  { label: "Relevans", value: "relevance", disabled: true },
+  { label: "Relevans", value: "relevance" },
   { label: "Fornavn", value: "firstName" },
   { label: "Efternavn", value: "lastName" },
   { label: "Fødselsår", value: "birthYear", disabled: true },


### PR DESCRIPTION
Jeg har implementeret det så lifecourses boostes en lille smule over kilder, og bruger en basisscore lig med den mest relevante kilde i livsforløbet.

Så for den mest relevante kilde viser vi først livsforløb, derefter kilderne, og ligeledes for den næst-mest-relevante kilde, osv.

Konkret:
- lifecourses får score efter "max" score på en person_appearance under den (default er "avg" der resulterede i at lifecourses altid blev vist længere nede på listen)
- score for lifecourses ganges med 1.05 (fordi nestede resultater pr default devalues en lille smule, så lifecourses altid var efter kilder; det vender vi om på denne måde)