### PR TITLE
Pagination detail fixing

### DIFF
--- a/src/app/search-result-list/search-result-list.component.html
+++ b/src/app/search-result-list/search-result-list.component.html
@@ -168,14 +168,14 @@
             </ng-container>
             
             <a class="lls-pagination__item" *ngFor="let page of pagination.navigationPages" [ngClass]="{ 'lls-pagination__item--selected': pagination.current === page }" [routerLink]="['./', { 'size': pagination.size, 'page': page } ]" [queryParams]="queryParams">
-                <span class="lls-pagination__item-text">{{ page }}</span>
+                <span class="lls-pagination__item-text">{{ prettyPaginationNumber(page) }}</span>
             </a>
 
             <ng-container *ngIf="pagination.lastInOrder < pagination.last">
                 <div class="lls-pagination__entry" *ngIf="pagination.lastInOrder < pagination.last - 1">&mdash;</div>
 
                 <a class="lls-pagination__item" [routerLink]="['./', { 'size': pagination.size, 'page': pagination.last } ]" [queryParams]="queryParams">
-                    <span class="lls-pagination__item-text">{{ pagination.last }}</span>
+                    <span class="lls-pagination__item-text">{{ prettyPaginationNumber(pagination.last) }}</span>
                 </a>
             </ng-container>
 

--- a/src/app/search-result-list/search-result-list.component.ts
+++ b/src/app/search-result-list/search-result-list.component.ts
@@ -90,13 +90,23 @@ export class SearchResultListComponent implements OnInit {
   }
 
   get resultRangeDescription() {
+    const prettyTotal = this.prettyPaginationNumber(this.searchResult.totalHits);
+
     if(this.searchResult.totalHits < this.pagination.size) {
-      return `Viser alle ${this.searchResult.totalHits} resultater`;
+      return `Viser alle ${prettyTotal} resultater`;
     }
 
     const firstResult = ((this.pagination.current - 1) * this.pagination.size) + 1;
     const lastResult = Math.min(firstResult + this.pagination.size - 1, this.searchResult.totalHits);
-    return `Viser ${firstResult}&ndash;${lastResult} af ${this.searchResult.totalHits} resultater`;
+
+    const prettyFirst = this.prettyPaginationNumber(firstResult);
+    const prettyLast = this.prettyPaginationNumber(lastResult);
+
+    return `Viser ${prettyFirst}&ndash;${prettyLast} af ${prettyTotal} resultater`;
+  }
+
+  prettyPaginationNumber(num: number) {
+    return num.toLocaleString("da-DK");
   }
 
   constructor(private router: Router, private route: ActivatedRoute) { }

--- a/src/assets/styling/pagination.scss
+++ b/src/assets/styling/pagination.scss
@@ -5,8 +5,9 @@
 }
 
 .lls-pagination__item {
-  width: 2rem;
+  min-width: 2rem;
   height: 2rem;
+  padding: 0 0.25rem;
   border: 2px solid transparent;
   border-radius: 3px;
   display: inline-flex;


### PR DESCRIPTION
- makes pagination numbers have thousand separators like proper big Danish numbers (easier to read)

![image](https://user-images.githubusercontent.com/859106/101344766-44719680-3886-11eb-9aed-ea67779c6fb3.png)

- makes pagination item boxes grow with the number, so the number always fits inside the box

![image](https://user-images.githubusercontent.com/859106/101344742-3ae82e80-3886-11eb-8f98-648442328e89.png)
