### PR TITLE
Bugfix allow view burials

### DIFF
--- a/src/app/person-appearance/person-appearance.component.html
+++ b/src/app/person-appearance/person-appearance.component.html
@@ -36,7 +36,7 @@
         <a href routerLink="source-data" [routerLinkActive]="'lls-tabs__item--active'" class="lls-tabs__item">
             <span class="lls-tabs__item-text">Kildeinfo</span>
         </a>
-        <a href routerLink="related-people" [routerLinkActive]="'lls-tabs__item--active'" class="lls-tabs__item">
+        <a href routerLink="related-people" [routerLinkActive]="'lls-tabs__item--active'" class="lls-tabs__item" *ngIf="this.hh">
             <span class="lls-tabs__item-text">Relaterede personer</span>
         </a>
     </div>

--- a/src/app/person-appearance/related-people.component.ts
+++ b/src/app/person-appearance/related-people.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnInit } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { PersonAppearance } from '../search/search.service';
 
 @Component({
@@ -9,13 +9,17 @@ import { PersonAppearance } from '../search/search.service';
 export class RelatedPeopleComponent implements OnInit {
   featherSpriteUrl = window["lls"].featherIconPath;
 
-  constructor(private route: ActivatedRoute) { }
+  constructor(private route: ActivatedRoute, private router: Router) { }
 
   relatedPas: Array<PersonAppearance>;
 
   ngOnInit(): void {
     this.route.parent.data.subscribe((resolve) => {
-      this.relatedPas = resolve.item.hh as Array<PersonAppearance>;
+      if(!resolve.item.hh) {
+        this.router.navigate([ "pa", resolve.item.pa.id, "source-data" ]);
+        return;
+      }
+      this.relatedPas = resolve.item.hh as PersonAppearance[];
     });
   }
 


### PR DESCRIPTION
For burials, we still tried to look up household-related people, but none exist (no hh_id), which resulted in an error in elasticsearch.

Now, we don't do that, and also hide the "Related people" tab for burials.