### PR TITLE
Add index query params to search history.

### DIFF
--- a/src/app/search-history/component.html
+++ b/src/app/search-history/component.html
@@ -29,9 +29,11 @@
                     </svg>
                     <span>Søgeresultat</span>
                 </h3>
-                <p class="u-margin-0" *ngFor="let item of entry.queryItems">
-                    <strong class="u-mr-2">{{ searchFieldLabels[item.field] }}</strong> {{ item.value }}
-                </p>
+                <ng-container *ngFor="let item of entry.queryItems">
+                    <p class="u-margin-0" *ngIf="item.field != 'index'">
+                        <strong class="u-mr-2">{{ searchFieldLabels[item.field] }}</strong> {{ item.value }}
+                    </p>
+                </ng-container>
             </div>
         </a>
         <a

--- a/src/app/search-result-list/search-result-resolver.service.ts
+++ b/src/app/search-result-list/search-result-resolver.service.ts
@@ -44,6 +44,7 @@ export class SearchResultResolverService implements Resolve<SearchResult> {
       "sourceYear",
       //"deathYear",
       //"maritalStatus",
+      "index",
     ];
 
     const actualSearchTerms: AdvancedSearchQuery = {};

--- a/src/app/search-term-values.ts
+++ b/src/app/search-term-values.ts
@@ -91,6 +91,7 @@ export const searchFieldLabels = {
   birthYear: "Fødselsår",
   sourceYear: "Kildeår",
   deathYear: "Dødsår",
+  // index: "Resultattype",
   //maritalStatus: "Civilstand",
 };
 


### PR DESCRIPTION
Currently we do not save index query param in the search history. This means that the search history links basically always shows no results (because no sources/index is chosen).

This is a quick fix. We should show the index param in the search history markup as well, but for now its hidden.
Merging quickly to fix the bug, but feel free to review and lets stabilize this thing :).