### PR TITLE
Cleanup Search History index query params

### DIFF
--- a/src/app/search-history.ts
+++ b/src/app/search-history.ts
@@ -12,6 +12,7 @@ export enum SearchHistoryEntryType {
 export interface SearchHistoryEntry {
   type: SearchHistoryEntryType,
   query?: AdvancedSearchQuery,
+  index?: string[],
   lifecourse?: LifecourseSearchHistoryEntry,
   personAppearance?: PersonAppearance,
 }

--- a/src/app/search-history/component.html
+++ b/src/app/search-history/component.html
@@ -15,7 +15,9 @@
           </svg>
         </button>
     </div>
-    <ng-container *ngFor="let entry of searchHistory" [ngSwitch]="entry.type">
+    <ng-container
+        *ngFor="let entry of searchHistory"
+        [ngSwitch]="entry.type">
         <a
             *ngSwitchCase="'search_result'"
             class="lls-sidebar__item lls-sidebar__item--link lls-search-history__item lls-search-history__item-link"

--- a/src/app/search-history/component.html
+++ b/src/app/search-history/component.html
@@ -21,7 +21,7 @@
             class="lls-sidebar__item lls-sidebar__item--link lls-search-history__item lls-search-history__item-link"
             [tabIndex]="openSearchHistory ? 0 : -1"
             [routerLink]="['/results']"
-            [queryParams]="entry.query"
+            [queryParams]="queryParams(entry)"
             (click)="closeSearchHistory()"
         >
             <div>

--- a/src/app/search-history/component.ts
+++ b/src/app/search-history/component.ts
@@ -29,6 +29,13 @@ export class SearchHistoryComponent implements OnInit {
     return Object.keys(entry.query);
   }
 
+  queryParams(entry) {
+    return {
+      ...entry.query,
+      index: entry.index
+    };
+  }
+
   ngOnInit(): void {
     onSearchHistoryEntry((history) => this.searchHistory = history);
   }

--- a/src/app/search-result-list/search-result-resolver.service.ts
+++ b/src/app/search-result-list/search-result-resolver.service.ts
@@ -54,7 +54,6 @@ export class SearchResultResolverService implements Resolve<SearchResult> {
       "sourceYear",
       //"deathYear",
       //"maritalStatus",
-      "index",
     ];
 
     const actualSearchTerms: AdvancedSearchQuery = {};
@@ -70,6 +69,7 @@ export class SearchResultResolverService implements Resolve<SearchResult> {
     addSearchHistoryEntry({
       type: SearchHistoryEntryType.SearchResult,
       query: actualSearchTerms,
+      index,
     });
 
     return this.service.advancedSearch(actualSearchTerms, index, (page - 1) * size, size, sortBy, sortOrder, sourceFilter);


### PR DESCRIPTION
### Changes:
Remove index from queryParams.
Add index as a part of a SearchHistory entry instead