### PR TITLE
Align button height with inputs

### DIFF
--- a/src/assets/styling/button.scss
+++ b/src/assets/styling/button.scss
@@ -1,17 +1,16 @@
 .lls-btn {
   display: inline-flex;
   align-items: center;
-  padding: .5rem 1rem;
+  padding: 0.535rem 1rem;
   color: white;
   background-color: #000;
-  border: none;
+  border: 2px solid;
+  border-color: #000;
   border-radius: 2px;
   text-transform: uppercase;
   font-weight: 600;
-  font-size: 0.8125rem;
+  font-size: 1rem;
   letter-spacing: 1.2px;
-  font-family: founders, Helvetica, Arial, sans-serif;
-  letter-spacing: 0.1rem;
 
   &:hover {
     background-color: lighten(#000, 5%);
@@ -34,11 +33,6 @@
 .lls-btn--big {
   padding: 1.15rem 1.5rem;
   border-radius: 3px;
-  font-size: 0.95rem;
-}
-
-.lls-btn--medium {
-  padding: 0.75rem 1rem;
 }
 
 .lls-btn--small {
@@ -49,6 +43,7 @@
   cursor: default;
   color: rgb(200, 200, 200);
   background-color: rgb(55, 55, 55);
+  border-color: rgb(55, 55, 55);
 
   &:hover {
     background-color: rgb(55, 55, 55);
@@ -90,7 +85,7 @@
 
 .lls-btn--outline {
   background-color: transparent;
-  border: 2px solid $off-black;
+  border-color: $off-black;
   color: $off-black;
   text-transform: none;
 


### PR DESCRIPTION
### Changes:
- Add border to all button types. This makes it easier to align them since their heights are the same and such.
- Cleanup CSS.
- Change padding slightly to align height with inputs.
- Font size is now 16px and not 13px.

### Screenshot:
![image](https://user-images.githubusercontent.com/8166831/102625797-4f5dde00-4146-11eb-9d4a-9d1610941348.png)
