### PR TITLE
Fix bugs in index params

### DIFF
--- a/src/app/search-history.ts
+++ b/src/app/search-history.ts
@@ -62,7 +62,7 @@ export function getSearchHistory(): SearchHistoryEntry[] {
 export function getLatestSearchQuery() {
   const latestSearch = getSearchHistory().filter(item => item.type === "search_result")[0];
   if(latestSearch) {
-    return { ...latestSearch.query, index: latestSearch.index };
+    return { ...latestSearch.query, index: latestSearch.index.join(",") };
   }
   return { query: "" };
 }

--- a/src/app/search-history/component.ts
+++ b/src/app/search-history/component.ts
@@ -30,10 +30,13 @@ export class SearchHistoryComponent implements OnInit {
   }
 
   queryParams(entry) {
-    return {
+    let queryParams = {
       ...entry.query,
-      index: entry.index
-    };
+    }
+    if(entry.index && entry.index != "") {
+      queryParams.index = entry.index.join(",");
+    }
+    return queryParams;
   }
 
   ngOnInit(): void {

--- a/src/app/search-history/component.ts
+++ b/src/app/search-history/component.ts
@@ -33,7 +33,7 @@ export class SearchHistoryComponent implements OnInit {
     let queryParams = {
       ...entry.query,
     }
-    if(entry.index && entry.index != "") {
+    if(Array.isArray(entry.index)) {
       queryParams.index = entry.index.join(",");
     }
     return queryParams;

--- a/src/app/search-result-list/search-result-list.component.ts
+++ b/src/app/search-result-list/search-result-list.component.ts
@@ -141,6 +141,8 @@ export class SearchResultListComponent implements OnInit {
 
       const indices = queryParamMap.get('index');
       if(indices) {
+        // Reset index checkbox values
+        Object.keys(this.indices).forEach(index => this.indices[index].value = false);
         indices.split(",").forEach((index) => this.indices[index].value = true);
       }
       this.sortBy = queryParamMap.get('sortBy') || "relevance";


### PR DESCRIPTION
Changes:
- Joined arrays with "," when adding index as a queryParam. If index is an array the queryParams inserts it multiple times (ala `index=pas,index=lifecourses` instead of `index=pas,lifecourses`).
- Fix issue where the checkboxes where not checked off when using the links in search history.