### PR TITLE
Display correct burial data on lifecourses

### DIFF
--- a/src/app/life-course/life-course.component.html
+++ b/src/app/life-course/life-course.component.html
@@ -19,7 +19,9 @@
         </div>
         <div class="lls-data-page-header__classification">
             <h2 class="lls-data-page-header__source-type">Livsforløb</h2>
-            <h1 class="lls-data-page-header__title u-text-capitalize">{{ latestPersonAppearance.name_clean }}</h1>
+            <h1 class="lls-data-page-header__title u-text-capitalize">
+                {{ personName }}
+            </h1>
             <div class="lls-data-page-header__data-summary">
                 <p class="u-text-capitalize u-mr-2">
                     <span class="u-text-grey--light u-mr-2">Fødested</span> {{ birthLocation }}
@@ -30,6 +32,14 @@
                     </svg>
                     {{ birthYear }}
                 </p>
+                <ng-container *ngIf="deathYear">
+                    <p class="u-align-icon">
+                        <svg class="lls-icon lls-icon--filled lls-icon--small lls-icon--left">
+                            <use [attr.href]="featherSpriteUrl + '#ll-dead'"></use>
+                        </svg>
+                        {{ deathYear }}
+                    </p>
+                </ng-container>
             </div>
         </div>
     </section>

--- a/src/app/life-course/life-course.component.ts
+++ b/src/app/life-course/life-course.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { Link } from '../elasticsearch/elasticsearch.service';
-import { prettyBirthLocation, prettyBirthYear, prettyDate } from '../display-helpers';
+import { prettyFullName, prettyBirthLocation, prettyBirthYear, prettyDeathYear, prettyDate } from '../display-helpers';
 import { PersonAppearance } from '../search/search.service';
 import { getLatestSearchQuery } from '../search-history';
 
@@ -120,12 +120,24 @@ export class LifeCourseComponent implements OnInit {
     return sortedByYear[sortedByYear.length - 1];
   }
 
+  get personName() {
+    return prettyFullName(this.latestPersonAppearance);
+  }
+
   get birthLocation() {
+    if(this.latestPersonAppearance.event_type === "burial") {
+      // Burials does not have birth location data so we use another PA.
+      return prettyBirthLocation(this.pas[0]);
+    }
     return prettyBirthLocation(this.latestPersonAppearance);
   }
 
   get birthYear() {
     return prettyBirthYear(this.latestPersonAppearance);
+  }
+
+  get deathYear() {
+    return prettyDeathYear(this.latestPersonAppearance);
   }
 
   get lastUpdated() {

--- a/src/app/search-history/component.html
+++ b/src/app/search-history/component.html
@@ -62,13 +62,13 @@
                     </span>
                 </h3>
                 <p class="u-text-capitalize u-margin-0">
-                    <strong class="u-mr-2">Navn</strong> {{ entry.lifecourse.personAppearances[entry.lifecourse.personAppearances.length - 1].name_clean }}
+                    <strong class="u-mr-2">Navn</strong> {{ prettyFullName(entry.lifecourse.personAppearances[entry.lifecourse.personAppearances.length - 1]) }}
                 </p>
                 <p class="u-margin-0">
                     <strong class="u-mr-2">Født</strong> {{ prettyBirthYear(entry.lifecourse.personAppearances[entry.lifecourse.personAppearances.length - 1]) }}
                 </p>
                 <p class="u-text-capitalize u-margin-0">
-                    <strong class="u-mr-2">Fødested</strong> {{ prettyBirthLocation(entry.lifecourse.personAppearances[entry.lifecourse.personAppearances.length - 1]) }}
+                    <strong class="u-mr-2">Fødested</strong> {{ prettyBirthLocation(entry.lifecourse.personAppearances[0]) }}
                 </p>
             </div>
         </a>


### PR DESCRIPTION
### Changes:
- Use display helpers on lifecourse page. These basically does all the work for us.
- Use the same helpers in the search history. Lifecourse entries with burials had the same problems where names and birthlocations where not show.
- Add death year to lifecourse page (if we have it).

### Screenshot:
![image](https://user-images.githubusercontent.com/8166831/107021180-2223c880-67a4-11eb-9bdf-5cb5bdd7f1f8.png)
