### PR TITLE
Add query field as an option in advanced search

### DIFF
--- a/src/app/search-term-values.ts
+++ b/src/app/search-term-values.ts
@@ -121,6 +121,10 @@ export const allYearFields: Array<Option | Category> = [
   "deathYear"
 ].map((f) => toFieldOption(f));
 
+export const allOtherFields: Array<Option | Category> = [
+  "query"
+].map((f) => toFieldOption(f));
+
 export const fieldOptions = [
   { category: "Navn" },
   ...allNameFields,
@@ -128,6 +132,8 @@ export const fieldOptions = [
   ...allPlaceFields,
   { category: "År" },
   ...allYearFields,
+  { category: "Andet" },
+  ...allOtherFields,
 ];
 
 export function getFieldOptions(filter) {
@@ -149,9 +155,16 @@ export function getFieldOptions(filter) {
     yearOptions = [ { category: "År" }, ...notUsedYearFields ];
   }
 
+  const notUsedOtherFields = allOtherFields.filter(filter);
+  let otherOptions = [];
+  if(notUsedOtherFields.length > 0) {
+    otherOptions = [ { category: "Andet" }, ...notUsedOtherFields ];
+  }
+
   return [
     ...nameOptions,
     ...placeOptions,
     ...yearOptions,
+    ...otherOptions
   ];
 }


### PR DESCRIPTION
### Changes:
- Add "fritekst" (query) as an option in the "add field" dropdown for advanced search.
- Create "other" category that fritekst belongs in.

Trello:
https://trello.com/c/QeIp0XnF/92-mulighed-for-at-tilf%C3%B8je-friteksts%C3%B8gning-i-felterne-i-det-bl%C3%A5-b%C3%A5nd-%C3%B8verst-i-s%C3%B8geresultatvisning