### PR TITLE
Census sources updates 20210210

### DIFF
--- a/src/app/life-course/life-course.component.html
+++ b/src/app/life-course/life-course.component.html
@@ -175,12 +175,7 @@
                 <h3 class="lls-data-page-footer__entry-label">
                     Om livsforløb
                 </h3>
-                <p>
-                    Et Livsforløb er et kvalificeret forslag til hvilke historiske kilder, der handler om den samme person. Der kommer løbende flere livsforløb i søgningen og der kan komme flere detaljer på et livsforløb.
-                </p>
-                <p>
-                    Livsforløb består af en række personoplysninger fra kilder som folketællinger og kirkebøger, der er blevet standardiseret for at kunne blive sammenlignet og forbundet digitalt.
-                </p>
+                <div [innerHTML]="aboutLifeCourseText"></div>
             </div>
         </div>
     </section>

--- a/src/app/life-course/life-course.component.ts
+++ b/src/app/life-course/life-course.component.ts
@@ -27,6 +27,10 @@ export class LifeCourseComponent implements OnInit {
     return [ ...this.pas ].reverse();
   }
 
+  get aboutLifeCourseText() {
+    return this.config.aboutLifeCourseText;
+  }
+
   get drawableLinks() {
     //These represent gaps, not PAs, so there is one less than there are PAs in order.
     const maxTiers = Array(this.pas.length - 1).fill(-1);

--- a/src/app/person-appearance/person-appearance-item.component.html
+++ b/src/app/person-appearance/person-appearance-item.component.html
@@ -1,4 +1,4 @@
-<div class="lls-source" [class]="'lls-source--' + personAppearance.event_type">
+<div class="lls-source" [class]="computedClass">
     <div class="lls-source__header lls-source__section">
         <div class="lls-source__symbol">
             <svg class="lls-icon">
@@ -56,13 +56,18 @@
     </div>
     
     <div class="lls-source__section lls-source__section--cta">
-        <div>
+        <div *ngIf="!selected">
             <a [routerLink]="['/pa', personAppearance.source_id + '-' + personAppearance.pa_id]" class="lls-btn lls-btn--link">
                 <span>Se kilde</span>
                 <svg class="lls-icon lls-icon--right">
                     <use [attr.href]="featherSpriteUrl + '#arrow-right'"></use>
                 </svg>
             </a>
+        </div>
+        <div *ngIf="selected">
+            <svg class="lls-icon lls-icon--large" [class]="'lls-icon--' + personAppearance.event_type">
+                <use [attr.href]="featherSpriteUrl + '#flag'"></use>
+            </svg>
         </div>
     </div>
 </div>

--- a/src/app/person-appearance/person-appearance-item.component.ts
+++ b/src/app/person-appearance/person-appearance-item.component.ts
@@ -10,6 +10,7 @@ export class PersonAppearanceItemComponent implements OnInit {
 
   @Input("item") personAppearance: PersonAppearance;
   @Input("truncatableName") showTitleOnName: boolean = false;
+  @Input("selected") selected: boolean = false;
 
   get config() {
     return window["lls"];
@@ -19,6 +20,16 @@ export class PersonAppearanceItemComponent implements OnInit {
 
   get eventType() {
     return eventType(this.personAppearance);
+  }
+
+  get computedClass() {
+    const classList = [ 'lls-source--' + this.personAppearance.event_type ];
+
+    if(this.selected) {
+      classList.push('lls-source--selected');
+    }
+
+    return classList.join(" ");
   }
 
   get eventIcon() {

--- a/src/app/person-appearance/person-appearance.component.html
+++ b/src/app/person-appearance/person-appearance.component.html
@@ -36,7 +36,7 @@
             <span class="lls-tabs__item-text">Kildeinfo</span>
         </a>
         <a href routerLink="related-people" [routerLinkActive]="'lls-tabs__item--active'" class="lls-tabs__item" *ngIf="this.hh">
-            <span class="lls-tabs__item-text">Relaterede personer</span>
+            <span class="lls-tabs__item-text">{{ relatedPersonsTitle }}</span>
         </a>
     </div>
 

--- a/src/app/person-appearance/person-appearance.component.ts
+++ b/src/app/person-appearance/person-appearance.component.ts
@@ -29,6 +29,13 @@ export class PersonAppearanceComponent implements OnInit {
     return prettyDate(this.pa.last_updated);
   }
 
+  get relatedPersonsTitle() {
+    if(this.pa.event_type === "census") {
+      return "Husstand";
+    }
+    return "Relaterede personer";
+  }
+
   ngOnInit(): void {
     this.route.data.subscribe((resolve) => {
       this.pa = resolve.item.pa as PersonAppearance;

--- a/src/app/person-appearance/related-people.component.html
+++ b/src/app/person-appearance/related-people.component.html
@@ -2,7 +2,7 @@
   <app-person-appearance-item
     [item]="pa"
     class="lls-columns-12"
+    [selected]="pa.id == currentPa.id"
     *ngFor="let pa of relatedPas"
   ></app-person-appearance-item>
 </section>
-  

--- a/src/app/person-appearance/related-people.component.ts
+++ b/src/app/person-appearance/related-people.component.ts
@@ -20,9 +20,20 @@ export class RelatedPeopleComponent implements OnInit {
         this.router.navigate([ "pa", resolve.item.pa.id, "source-data" ]);
         return;
       }
-      this.relatedPas = resolve.item.hh as PersonAppearance[];
+      this.relatedPas = this.sortBy(resolve.item.hh, "transcription_id") as PersonAppearance[];
       this.currentPa = resolve.item.pa;
     });
   }
 
+  sortBy(list, key: string) {
+    return list.sort((a, b) => {
+      if(a[key] < b[key]) {
+        return -1;
+      }
+      if(a[key] > b[key]) {
+        return 1;
+      }
+      return 0;
+    })
+  }
 }

--- a/src/app/person-appearance/related-people.component.ts
+++ b/src/app/person-appearance/related-people.component.ts
@@ -12,6 +12,7 @@ export class RelatedPeopleComponent implements OnInit {
   constructor(private route: ActivatedRoute, private router: Router) { }
 
   relatedPas: Array<PersonAppearance>;
+  currentPa: PersonAppearance;
 
   ngOnInit(): void {
     this.route.parent.data.subscribe((resolve) => {
@@ -20,6 +21,7 @@ export class RelatedPeopleComponent implements OnInit {
         return;
       }
       this.relatedPas = resolve.item.hh as PersonAppearance[];
+      this.currentPa = resolve.item.pa;
     });
   }
 

--- a/src/app/person-appearance/source-data.component.ts
+++ b/src/app/person-appearance/source-data.component.ts
@@ -86,7 +86,7 @@ export class SourceDataComponent implements OnInit {
         }
         return !isUndef;
       })
-      .map((key) => ({ label: this.standardizedDataFields[this.pa.event_type][key], value: this.pa[key] }));
+      .map((key) => ({ label: this.standardizedDataFields[this.pa.event_type][key], value: this.cleanValue(this.pa[key]) }));
   }
 
   sourceDataFields = {
@@ -115,7 +115,7 @@ export class SourceDataComponent implements OnInit {
         }
         return !isUndef;
       })
-      .map((key) => ({ label: this.sourceDataFields[this.pa.event_type][key], value: this.pa[key] }));
+      .map((key) => ({ label: this.sourceDataFields[this.pa.event_type][key], value: this.cleanValue(this.pa[key]) }));
   }
 
   excludeDataFields = [
@@ -135,7 +135,7 @@ export class SourceDataComponent implements OnInit {
 
     return Object.keys(this.pa)
       .filter((key) => !alreadyUsedFields.includes(key))
-      .map((key) => ({ label: key, value: this.pa[key] }));
+      .map((key) => ({ label: key, value: this.cleanValue(this.pa[key]) }));
   }
 
   originalDataFields = {
@@ -205,7 +205,14 @@ export class SourceDataComponent implements OnInit {
         }
         return !isUndef;
       })
-      .map((key) => ({ label: this.originalDataFields[this.pa.event_type][key], value: this.pa[key] }));
+      .map((key) => ({ label: this.originalDataFields[this.pa.event_type][key], value: this.cleanValue(this.pa[key]) }));
+  }
+
+  cleanValue(value) {
+    if(Array.isArray(value)) {
+      return value.join(", ");
+    }
+    return value;
   }
 
   ngOnInit(): void {

--- a/src/assets/styling/data-page-data-section.scss
+++ b/src/assets/styling/data-page-data-section.scss
@@ -21,6 +21,8 @@
   th {
     font-weight: 400;
     padding-right: 1rem;
+    padding-top: 0.75rem;
     width: 33%;
+    vertical-align: top;
   }
 }

--- a/src/assets/styling/data-page-footer.scss
+++ b/src/assets/styling/data-page-footer.scss
@@ -1,5 +1,6 @@
 .lls-data-page-footer {
   display: flex;
+  margin-top: 3rem;
 }
 
 .lls-data-page-footer__entry {

--- a/src/assets/styling/icon.scss
+++ b/src/assets/styling/icon.scss
@@ -29,3 +29,21 @@
 .lls-icon--left {
   margin-right: 0.25rem;
 }
+
+.lls-icon--large {
+  width: 1.5em;
+  height: 1.5em;
+  margin: 1em;
+}
+
+.lls-icon--census {
+  stroke: $yellow;
+}
+
+.lls-icon--burial {
+  stroke: $burial-grey;
+}
+
+.lls-icon--lifecourse {
+  stroke: white;
+}

--- a/src/assets/styling/source-card.scss
+++ b/src/assets/styling/source-card.scss
@@ -2,9 +2,11 @@
   display: flex;
   flex-direction: column;
   background-color: white;
-  border-left: 10px solid;
-  border-left-color: $blue;
-  
+  border-style: solid;
+  border-width: 0;
+  border-left-width: 10px;
+  border-color: $blue;
+  overflow: hidden;
 
   @media(min-width: $breakpointMd) {
     flex-direction: row;
@@ -16,14 +18,18 @@
     content: "";
     width: 16px;
     background-color: $blue;
-    border-top-left-radius: 10px;
-    border-bottom-left-radius: 10px;
     flex-shrink: 0
   }
 }
 
+.lls-source--selected {
+  border-top-width: 3px;
+  border-right-width: 3px;
+  border-bottom-width: 3px;
+}
+
 .lls-source--census {
-  border-left-color: $yellow;
+  border-color: $yellow;
 
   &::before {
     background-color: $yellow;
@@ -31,7 +37,7 @@
 }
 
 .lls-source--burial {
-  border-left-color: $burial-grey;
+  border-color: $burial-grey;
 
   &::before {
     background-color: $burial-grey;
@@ -40,7 +46,7 @@
 
 .lls-source--lifecourse {
   background-color: $blue--dark;
-  border-left-color: $blue--darker;
+  border-color: $blue--darker;
   color: white;
 
   &::before {

--- a/src/index.html
+++ b/src/index.html
@@ -58,6 +58,15 @@
           title: "Find livsforløb 1787–1901",
           introText: `<p>Livsforløb er forslag til hvilke historiske kilder, der omhandler den samme person.</p><p>Vi tilføjer løbende flere livsforløb og der kan komme nye detaljer og ændringer på et livsforløb efterhånden som projektets metoder forbedres.</p><p><a href="https://link-lives.dk/livsforloeb/">Læs mere om livsforløb</a></p>`,
           helpBoxText: "<p><strong>Du søger livsforløb i kilderne</strong></p><p>Lorem ipsum dolor sit amet.</p>",
+          aboutLifeCourseText: `
+            <p>
+              Et Livsforløb er et kvalificeret forslag til hvilke historiske kilder, der handler om den samme person. Der kommer løbende flere livsforløb 
+i søgningen og der kan komme flere detaljer på et livsforløb.
+            </p>
+            <p>
+              Livsforløb består af en række personoplysninger fra kilder som folketællinger og kirkebøger, der er blevet standardiseret for at kunne blive sammenlignet og forbundet digitalt.
+            </p>
+          `,
         };
       </script>
       <app-root></app-root>


### PR DESCRIPTION
- Omdøb "relaterede personer" til "husstand" for folketællinger
- Fremhæv den kilde man allerede er på under "relaterede personer"
- Sorter husstandens medlemmer efter transkriptions-ID
- Lange værdier ombrydes i flere linjer
- "Om livsforløb" text at end of lifecourses editable via config