### PR TITLE
Make hidden elements not tabbable in search result header

### DIFF
--- a/src/app/filter-sidebar/view.html
+++ b/src/app/filter-sidebar/view.html
@@ -3,6 +3,7 @@
   <div class="lls-sidebar__header">
     <h3 class="u-margin-0">Vælg kilder</h3>
     <button
+      [tabindex]="openSidebar ? 0 : -1"
       class="lls-btn lls-btn--outline"
       (click)="close()"
     >
@@ -16,6 +17,7 @@
     <button
       *ngIf="sidebarCategoryOpen"
       class="lls-filter-sidebar__option lls-sidebar__item"
+      [tabindex]="openSidebar ? 0 : -1"
       (click)="toggleCategory('')"
     >
     <svg class="lls-filter-sidebar__option-icon lls-icon">
@@ -27,6 +29,7 @@
       <ng-container *ngIf="!sidebarCategoryOpen">
         <button
           class="lls-filter-sidebar__option lls-sidebar__item"
+          [tabindex]="openSidebar ? 0 : -1"
           (click)="toggleCategory(category.key)"
          >
           <svg class="lls-icon lls-icon--left u-mr-2">
@@ -43,8 +46,9 @@
         <button
           *ngFor="let option of category.value, index as i"
           class="lls-filter-sidebar__option lls-sidebar__item"
-          (click)="addFilter(option)"
           [class]="activeFilter(option.value) ? 'lls-filter-sidebar__option--active' : ''"
+          [tabindex]="openSidebar ? 0 : -1"
+          (click)="addFilter(option)"
         >
           <svg class="lls-icon lls-icon--left u-mr-2">
             <use [attr.href]="featherIconPath + '#' + (activeFilter(option.value) ? 'check-square' : 'square')"></use>

--- a/src/app/search-result-list/search-result-list.component.html
+++ b/src/app/search-result-list/search-result-list.component.html
@@ -117,7 +117,10 @@
                 (closeSidebar)="closeSidebar($event)"
                 (removeFilter)="removeFilter($event)"
             ></lls-filter-sidebar>
-            <div class="lls-results-filter__items">
+            <div
+                *ngIf="sourceFilter.length"
+                class="lls-results-filter__items"
+            >
                 <div
                     *ngFor="let filterItem of sourceFilter; index as i;"
                     class="lls-btn lls-btn--grey u-mr-2 u-mt-2 u-text-capitalize"


### PR DESCRIPTION
### Changes:
- Make all buttons inside the sidebar tabindex -1 when the sidebar is not open.
- Hide "current chosen filters" section when there is no chosen filters.