### PR TITLE
Når man går tilbage til søgeresultatside fra søgehistorik, skal den huske siden man var på

### DIFF
--- a/src/app/search-history.ts
+++ b/src/app/search-history.ts
@@ -9,6 +9,11 @@ export enum SearchHistoryEntryType {
   Census = "census",
 }
 
+export interface SearchResultPagination {
+  page: Number,
+  size: Number,
+}
+
 export interface SearchHistoryEntry {
   type: SearchHistoryEntryType,
   query?: AdvancedSearchQuery,
@@ -16,6 +21,7 @@ export interface SearchHistoryEntry {
   lifecourse?: LifecourseSearchHistoryEntry,
   personAppearance?: PersonAppearance,
   timestamp?: Date,
+  pagination?: SearchResultPagination,
 }
 
 export interface LifecourseSearchHistoryEntry {
@@ -38,12 +44,12 @@ export function addSearchHistoryEntry(entry: SearchHistoryEntry): void {
 
   const existingHistory = getSearchHistory();
 
-  const entryData = unpick(entry, "timestamp");
+  const entryData = unpick(entry, "timestamp", "pagination");
 
   const history = [
     entry,
     ...existingHistory.filter((existingEntry) => {
-      return !isEqual(entryData, unpick(existingEntry, "timestamp"));
+      return !isEqual(entryData, unpick(existingEntry, "timestamp", "pagination"));
     })
   ].slice(0, 50);
 
@@ -78,10 +84,10 @@ export function getLatestSearchQuery() {
   return { query: "" };
 }
 
-function unpick(obj, key) {
+function unpick(obj, ...keys) {
   const result = {};
   Object.keys(obj)
-    .filter((objKey) => objKey != key)
+    .filter((objKey) => !keys.includes(objKey))
     .forEach((objKey) => result[objKey] = obj[objKey]);
   return result;
 }

--- a/src/app/search-history.ts
+++ b/src/app/search-history.ts
@@ -1,5 +1,5 @@
 import isEqual from 'lodash.isequal';
-import { AdvancedSearchQuery, PersonAppearance } from './search/search.service';
+import { AdvancedSearchQuery, PersonAppearance, SourceIdentifier } from './search/search.service';
 
 const LOCAL_STORAGE_KEY = "lls_search_history";
 
@@ -14,14 +14,21 @@ export interface SearchResultPagination {
   size: Number,
 }
 
+export interface SearchResultSorting {
+  sortBy: string,
+  sortOrder: "asc" | "desc",
+}
+
 export interface SearchHistoryEntry {
   type: SearchHistoryEntryType,
   query?: AdvancedSearchQuery,
+  sourceFilter?: SourceIdentifier[],
   index?: string[],
   lifecourse?: LifecourseSearchHistoryEntry,
   personAppearance?: PersonAppearance,
   timestamp?: Date,
   pagination?: SearchResultPagination,
+  sort?: SearchResultSorting,
 }
 
 export interface LifecourseSearchHistoryEntry {
@@ -44,12 +51,12 @@ export function addSearchHistoryEntry(entry: SearchHistoryEntry): void {
 
   const existingHistory = getSearchHistory();
 
-  const entryData = unpick(entry, "timestamp", "pagination");
+  const entryData = unpick(entry, "timestamp", "pagination", "sort", "sourceFilter");
 
   const history = [
     entry,
     ...existingHistory.filter((existingEntry) => {
-      return !isEqual(entryData, unpick(existingEntry, "timestamp", "pagination"));
+      return !isEqual(entryData, unpick(existingEntry, "timestamp", "pagination", "sort", "sourceFilter"));
     })
   ].slice(0, 50);
 

--- a/src/app/search-history/component.ts
+++ b/src/app/search-history/component.ts
@@ -35,12 +35,16 @@ export class SearchHistoryComponent implements OnInit {
   }
 
   queryParams(entry) {
-    let queryParams = {
-      ...entry.query,
+    let queryParams = { ...entry.query };
+
+    if(entry.pagination) {
+      queryParams = { ...queryParams, ...entry.pagination };
     }
+
     if(Array.isArray(entry.index)) {
       queryParams.index = entry.index.join(",");
     }
+
     return queryParams;
   }
 

--- a/src/app/search-history/component.ts
+++ b/src/app/search-history/component.ts
@@ -41,6 +41,19 @@ export class SearchHistoryComponent implements OnInit {
       queryParams = { ...queryParams, ...entry.pagination };
     }
 
+    if(entry.sort) {
+      queryParams = { ...queryParams, ...entry.sort };
+    }
+
+    if(entry.sourceFilter) {
+      queryParams = {
+        ...queryParams,
+        sourceFilter: entry.sourceFilter
+          .map(({ event_type, source_year }) => `${event_type}_${source_year}`)
+          .join(",")
+      };
+    }
+
     if(Array.isArray(entry.index)) {
       queryParams.index = entry.index.join(",");
     }

--- a/src/app/search-result-list/search-result-list.component.html
+++ b/src/app/search-result-list/search-result-list.component.html
@@ -115,7 +115,7 @@
                 [openSidebar]="openSidebar"
                 [featherIconPath]="config.featherIconPath"
                 [possibleSources]="possibleSources"
-                (closeSidebar)="closeSidebar($event)"
+                (closeSidebar)="closeSidebar()"
                 (removeFilter)="removeFilter($event)"
             ></lls-filter-sidebar>
             <div

--- a/src/app/search-result-list/search-result-list.component.html
+++ b/src/app/search-result-list/search-result-list.component.html
@@ -200,8 +200,8 @@
                 [ngClass]="{ 'lls-pagination__item--disabled': pagination.current === 1}" 
                 [tabindex]=" pagination.current === 1 ? -1 : 0"
                 aria-label="gå til forrige side"
-                [routerLink]="['./', { 'size': pagination.size, 'page': pagination.current - 1 } ]"
-                [queryParams]="queryParams"
+                [routerLink]="['./']"
+                [queryParams]="paginationQueryParams(pagination.current - 1)"
             >
                 <svg class="lls-icon">
                     <use [attr.href]="featherSpriteUrl + '#arrow-left'"></use>
@@ -212,8 +212,8 @@
                 <a
                     class="lls-pagination__item"
                     aria-label="gå til første side"
-                    [routerLink]="['./', { 'size': pagination.size, 'page': 1 } ]"
-                    [queryParams]="queryParams"
+                    [routerLink]="['./']"
+                    [queryParams]="paginationQueryParams(1)"
                 >
                     <span class="lls-pagination__item-text">1</span>
                 </a>
@@ -228,8 +228,8 @@
             <a class="lls-pagination__item"
                 *ngFor="let page of pagination.navigationPages"
                 [ngClass]="{ 'lls-pagination__item--selected': pagination.current === page }"
-                [routerLink]="['./', { 'size': pagination.size, 'page': page } ]"
-                [queryParams]="queryParams"
+                [routerLink]="['./']"
+                [queryParams]="paginationQueryParams(page)"
             >
                 <span class="lls-pagination__item-text">
                     {{ prettyPaginationNumber(page) }}
@@ -245,8 +245,8 @@
                 </div>
                 <a
                     class="lls-pagination__item"
-                    [routerLink]="['./', { 'size': pagination.size, 'page': pagination.last } ]"
-                    [queryParams]="queryParams"
+                    [routerLink]="['./']"
+                    [queryParams]="paginationQueryParams(pagination.last)"
                 >
                     <span class="lls-pagination__item-text">
                         {{ prettyPaginationNumber(pagination.last) }}
@@ -259,8 +259,8 @@
                 [ngClass]="{ 'lls-pagination__item--disabled': pagination.current >= pagination.last }"
                 aria-label="gå til næste side"
                 [tabindex]="pagination.current >= pagination.last ? -1 : 0"
-                [routerLink]="['./', { 'size': pagination.size, 'page': pagination.current + 1 } ]"
-                [queryParams]="queryParams"
+                [routerLink]="['./']"
+                [queryParams]="paginationQueryParams(pagination.current + 1)"
             >
                 <svg class="lls-icon">
                     <use [attr.href]="featherSpriteUrl + '#arrow-right'"></use>

--- a/src/app/search-result-list/search-result-list.component.ts
+++ b/src/app/search-result-list/search-result-list.component.ts
@@ -222,7 +222,7 @@ export class SearchResultListComponent implements OnInit {
     this.search();
   }
 
-  closeSidebar(event) {
+  closeSidebar() {
     this.openSidebar = false;
     this.search();
   }

--- a/src/app/search-result-list/search-result-resolver.service.ts
+++ b/src/app/search-result-list/search-result-resolver.service.ts
@@ -70,6 +70,7 @@ export class SearchResultResolverService implements Resolve<SearchResult> {
       type: SearchHistoryEntryType.SearchResult,
       query: actualSearchTerms,
       index,
+      pagination: { page, size },
     });
 
     return this.service.advancedSearch(actualSearchTerms, index, (page - 1) * size, size, sortBy, sortOrder, sourceFilter);

--- a/src/app/search-result-list/search-result-resolver.service.ts
+++ b/src/app/search-result-list/search-result-resolver.service.ts
@@ -15,12 +15,12 @@ export class SearchResultResolverService implements Resolve<SearchResult> {
     state: RouterStateSnapshot
   ) : Observable<SearchResult> | Observable<never> {
 
-    let page: number = Number(route.paramMap.get('page'))
+    let page: number = Number(route.queryParamMap.get('page'))
     if (page < 1 || page == NaN) {
       page = 1;
     }
 
-    let size: number = Number(route.paramMap.get('size'));
+    let size: number = Number(route.queryParamMap.get('size'));
     if (size < 1 || page == NaN) {
       size = 10;
     }

--- a/src/app/search-result-list/search-result-resolver.service.ts
+++ b/src/app/search-result-list/search-result-resolver.service.ts
@@ -26,17 +26,20 @@ export class SearchResultResolverService implements Resolve<SearchResult> {
     }
 
     let sortBy: string = route.queryParamMap.get('sortBy') || "relevance";
-    let sortOrder: string = route.queryParamMap.get('sortOrder') === "desc" ? "desc" : "asc";
+    let sortOrder: "asc" | "desc" = route.queryParamMap.get('sortOrder') === "desc" ? "desc" : "asc";
     const sourceFilterRaw = route.queryParamMap.get("sourceFilter");
 
-    let sourceFilter = [];
+    let sourceFilter: SourceIdentifier[] = [];
     if(sourceFilterRaw) {
       sourceFilter = sourceFilterRaw
         .split(",")
         .filter(x => x)
         .map((id) => {
           const [ event_type, source_year ] = id.split("_");
-          return { event_type, source_year };
+          return {
+            event_type,
+            source_year: Number(source_year),
+          };
         });
     }
 
@@ -69,8 +72,10 @@ export class SearchResultResolverService implements Resolve<SearchResult> {
     addSearchHistoryEntry({
       type: SearchHistoryEntryType.SearchResult,
       query: actualSearchTerms,
+      sourceFilter,
       index,
       pagination: { page, size },
+      sort: { sortBy, sortOrder },
     });
 
     return this.service.advancedSearch(actualSearchTerms, index, (page - 1) * size, size, sortBy, sortOrder, sourceFilter);


### PR DESCRIPTION
- Tilføjer kildefilter, sideinfo (antal, sidenummer) og sorteringsinfo til søgehistorik-entries for søgeresultater
- Linker korrekt tilbage til søgeresultatsiden
- Fixer edge case hvor man kunne ende på tomme sider ved at filtrere efter at være gået til en senere side