### PR TITLE
Improved source bucket aggregation

### DIFF
--- a/src/app/elasticsearch/elasticsearch.service.ts
+++ b/src/app/elasticsearch/elasticsearch.service.ts
@@ -396,23 +396,18 @@ export class ElasticsearchService {
       return { resultLookupQuery, sourceLookupQuery };
     }
 
-    return {
-      resultLookupQuery: {
-        bool: {
-          must: [
-            { term: { life_course_id: query.lifeCourseId } },
-            resultLookupQuery,
-          ]
-        }
-      },
-      sourceLookupQuery: {
-        bool: {
-          must: [
-            { term: { life_course_id: query.lifeCourseId } },
-            sourceLookupQuery,
-          ]
-        }
+    const includeLifeCouseInQuery = (query) => ({
+      bool: {
+        must: [
+          { term: { life_course_id: query.lifeCourseId } },
+          query,
+        ]
       }
+    });
+
+    return {
+      resultLookupQuery: includeLifeCouseInQuery(resultLookupQuery),
+      sourceLookupQuery: includeLifeCouseInQuery(sourceLookupQuery),
     };
   }
 

--- a/src/app/elasticsearch/elasticsearch.service.ts
+++ b/src/app/elasticsearch/elasticsearch.service.ts
@@ -156,7 +156,7 @@ export class ElasticsearchService {
   search(indices: string[], body: any): Observable<SearchResult> {
     // TODO: Prettifiy the loading overlay code.
     this.loading.emit(true);
-    var result = new Observable<SearchResult>(observer => {
+    const result = new Observable<SearchResult>(observer => {
       this.http.post<ElasticSearchResult>(`${environment.apiUrl}/${indices.join(',')}/_search`, body)
         .subscribe(next => {
           try {

--- a/src/app/elasticsearch/elasticsearch.service.ts
+++ b/src/app/elasticsearch/elasticsearch.service.ts
@@ -349,7 +349,9 @@ export class ElasticsearchService {
         return;
       }
 
-      console.warn("[elasticsearch.service] key we don't know how to search on provided", queryKey);
+      if(queryKey != "lifeCourseId") {
+        console.warn("[elasticsearch.service] key we don't know how to search on provided", queryKey);
+      }
     });
 
     if(sourceFilter.length) {

--- a/src/app/elasticsearch/elasticsearch.service.ts
+++ b/src/app/elasticsearch/elasticsearch.service.ts
@@ -304,6 +304,7 @@ export class ElasticsearchService {
     Object.keys(query).filter((queryKey) => query[queryKey]).forEach((queryKey) => {
       const value = query[queryKey];
 
+      // Special case: query
       if(queryKey === "query") {
         must.push({
           simple_query_string: {
@@ -389,6 +390,7 @@ export class ElasticsearchService {
       return { resultLookupQuery, sourceLookupQuery };
     }
 
+    // Special case: life_course_id
     const includeLifeCouseInQuery = (query) => ({
       bool: {
         must: [

--- a/src/app/elasticsearch/elasticsearch.service.ts
+++ b/src/app/elasticsearch/elasticsearch.service.ts
@@ -372,7 +372,7 @@ export class ElasticsearchService {
       })
     }
 
-    const resultLookupQuery: Record<string, any> = {
+    const getFullPersonAppearanceQueryFromMustQuery = (must) => ({
       nested: {
         path: "person_appearance",
         query: {
@@ -380,17 +380,10 @@ export class ElasticsearchService {
         },
         score_mode: "max",
       },
-    };
-    
-    const sourceLookupQuery: Record<string, any> = {
-      nested: {
-        path: "person_appearance",
-        query: {
-          bool: { must: sourceLookupFilter },
-        },
-        score_mode: "max",
-      },
-    };
+    });
+
+    const resultLookupQuery: Record<string, any> = getFullPersonAppearanceQueryFromMustQuery(must);
+    const sourceLookupQuery: Record<string, any> = getFullPersonAppearanceQueryFromMustQuery(sourceLookupFilter);
 
     if(!query.lifeCourseId) {
       return { resultLookupQuery, sourceLookupQuery };

--- a/src/app/elasticsearch/elasticsearch.service.ts
+++ b/src/app/elasticsearch/elasticsearch.service.ts
@@ -4,7 +4,7 @@ import { HttpClient } from '@angular/common/http';
 import { forkJoin, Observable } from 'rxjs';
 import { environment } from 'src/environments/environment';
 import { mapQueryMustKey, mapQueryShouldKey, sortValues } from 'src/app/search-term-values';
-import { map } from 'rxjs/operators';
+import { map, share } from 'rxjs/operators';
 
 export interface ElasticDocResult {
   _index: "lifecourses" | "pas" | "links",
@@ -168,11 +168,11 @@ export class ElasticsearchService {
       sourceLookup?: Observable<ElasticSourceLookupResult>,
     };
     const requests: SearchRequests = {
-      search: this.http.post<ElasticSearchResult>(`${environment.apiUrl}/${indices.join(',')}/_search`, body),
+      search: this.http.post<ElasticSearchResult>(`${environment.apiUrl}/${indices.join(',')}/_search`, body).pipe(share()),
     };
 
     if(sourceFilterBody) {
-      requests.sourceLookup = this.http.post<ElasticSourceLookupResult>(`${environment.apiUrl}/${indices.join(',')}/_search`, sourceFilterBody);
+      requests.sourceLookup = this.http.post<ElasticSourceLookupResult>(`${environment.apiUrl}/${indices.join(',')}/_search`, sourceFilterBody).pipe(share());
     }
 
     // Prep observable that will send both requests and merge results in handleResult

--- a/src/app/elasticsearch/elasticsearch.service.ts
+++ b/src/app/elasticsearch/elasticsearch.service.ts
@@ -339,7 +339,7 @@ export class ElasticsearchService {
 
     const sourceFilterBody = {
       from: from,
-      size: size,
+      size: 0,
       query: {
         nested: {
           path: "person_appearance",

--- a/src/app/elasticsearch/elasticsearch.service.ts
+++ b/src/app/elasticsearch/elasticsearch.service.ts
@@ -391,11 +391,11 @@ export class ElasticsearchService {
     }
 
     // Special case: life_course_id
-    const includeLifeCouseInQuery = (query) => ({
+    const includeLifeCouseInQuery = (oldQuery) => ({
       bool: {
         must: [
           { term: { life_course_id: query.lifeCourseId } },
-          query,
+          oldQuery,
         ]
       }
     });

--- a/src/app/filter-sidebar/component.ts
+++ b/src/app/filter-sidebar/component.ts
@@ -1,5 +1,5 @@
-import { Component, OnInit, ElementRef, EventEmitter, forwardRef, Input, Output } from '@angular/core';
-import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { Component, OnInit, EventEmitter, forwardRef, Input, Output } from '@angular/core';
+import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { eventIcon, eventType, prettyNumbers } from '../display-helpers';
 
 export interface Option {
@@ -78,7 +78,7 @@ export class FilterSidebar implements OnInit {
   }
 
   activeFilter(optionValue) {
-    return this.filters.some((filterValue) => filterValue === optionValue)
+    return this.filters.some((filterValue) => filterValue === optionValue);
   }
 
   toggleCategory(type) {

--- a/src/app/filter-sidebar/component.ts
+++ b/src/app/filter-sidebar/component.ts
@@ -56,10 +56,31 @@ export class FilterSidebar implements OnInit {
 
   filtersWithLabels = [];
   sidebarCategoryOpen: String = undefined;
-  filtersCategories = {};
   _filters: number[] = [];
   onChange: Function = () => {};
   onTouched: Function = () => {};
+
+  get filtersCategories() {
+    const result = {};
+
+    this.possibleSources.forEach(x => {
+      const prettyEventType = eventType({ event_type: x.event_type });
+      const filter =  {
+        label: `${prettyEventType} ${x.source_year}`,
+        type: prettyEventType,
+        icon: eventIcon(x.event_type),
+        value: `${x.event_type}_${x.source_year}`,
+        count: prettyNumbers(x.count),
+        chosen: false,
+      };
+      if(!result[x.event_type]) {
+        result[x.event_type] = [];
+      }
+      result[x.event_type].push(filter);
+    });
+
+    return result;
+  }
 
   close() {
     this.onChange([...this.filters]);
@@ -92,22 +113,6 @@ export class FilterSidebar implements OnInit {
     }
   }
 
-  ngOnInit(): void {
-    this.possibleSources.forEach(x => {
-      const prettyEventType = eventType({ event_type: x.event_type });
-      const filter =  {
-        label: `${prettyEventType} ${x.source_year}`,
-        type: prettyEventType,
-        icon: eventIcon(x.event_type),
-        value: `${x.event_type}_${x.source_year}`,
-        count: prettyNumbers(x.count),
-        chosen: false,
-      };
-      if(!this.filtersCategories[x.event_type]) {
-        this.filtersCategories[x.event_type] = [];
-      }
-      this.filtersCategories[x.event_type].push(filter);
-    });
-  }
+  ngOnInit(): void {}
 
 }


### PR DESCRIPTION
The number of sources in a source bucket should not vary by source buckets picked. So we make 2 requests now, one to get source buckets, and another to get results. The source bucket request gets no results so is quite small in terms of data transfer (< 1 kb).

Additionally, this PR ensures that we update available buckets every time a search is changed (before, it only happened when the source bucket sidebar was created).