### PR TITLE
Wildcard search

### DIFF
--- a/src/app/elasticsearch/elasticsearch.service.ts
+++ b/src/app/elasticsearch/elasticsearch.service.ts
@@ -267,6 +267,12 @@ export class ElasticsearchService {
 
       const searchKey = searchKeyConfig[mode] || searchKeyConfig.default;
 
+      if(/[\?\*]/.test(value)) {
+        must.push({
+          wildcard: { [`person_appearance.${searchKey}`]: value }
+        });
+        return;
+      }
       must.push({
         match: { [`person_appearance.${searchKey}`]: value }
       });

--- a/src/app/elasticsearch/elasticsearch.service.ts
+++ b/src/app/elasticsearch/elasticsearch.service.ts
@@ -255,6 +255,7 @@ export class ElasticsearchService {
             query: value,
             fields: ["*"],
             default_operator: "and",
+            analyze_wildcard: true,
           },
         });
         return;


### PR DESCRIPTION
Note: merges into #99.

Adds support for wildcards `?` (any one single character) and `*` (zero or more of any characters) in search queries.