### PR TITLE
Move logic of flipping sort order to results list, so the URL says what we are actually doing

### DIFF
--- a/src/app/elasticsearch/elasticsearch.service.ts
+++ b/src/app/elasticsearch/elasticsearch.service.ts
@@ -207,10 +207,9 @@ export class ElasticsearchService {
 
     return sortKeys.map((key: string) => {
       if(key == "_score") {
-        //Magic: flip the relevance score ordering to fit expected mental model
-        return { _score: { order: sortOrder === "asc" ? "desc" : "asc" } };
+        // Special case: _score is top-level, not on person_appearance
+        return { _score: { order: sortOrder } };
       }
-
       const qualifiedKey = `person_appearance.${key}`;
 
       return {

--- a/src/app/search-result-list/search-result-list.component.ts
+++ b/src/app/search-result-list/search-result-list.component.ts
@@ -84,11 +84,16 @@ export class SearchResultListComponent implements OnInit {
   }
   
   get queryParams() {
+    let sortOrder = this.sortAscending ? "asc" : "desc";
+    if(this.sortBy === "relevance") {
+      sortOrder = this.sortAscending ? "desc" : "asc";
+    }
+
     return {
       ...this.searchQueryParams,
       index: this.computedIndex,
       sortBy: this.sortBy,
-      sortOrder: this.sortAscending ? "asc" : "desc",
+      sortOrder: sortOrder,
       sourceFilter: this.sourceFilter.join(",") || undefined,
     };
   }
@@ -160,7 +165,10 @@ export class SearchResultListComponent implements OnInit {
         indices.split(",").forEach((index) => this.indices[index].value = true);
       }
       this.sortBy = queryParamMap.get('sortBy') || "relevance";
-      this.sortAscending = !(queryParamMap.get('sortOrder') === "desc");
+
+      const sortOrder = queryParamMap.get('sortOrder');
+      this.sortAscending = this.sortBy === "relevance" ? sortOrder !== "asc" : sortOrder !== "desc";
+
       const sourceFilters = queryParamMap.get('sourceFilter');
       if(sourceFilters) {
         this.sourceFilter = sourceFilters


### PR DESCRIPTION
Arrow down now results in urls with sortOrder=asc EXCEPT for relevance, where it is sortOrder=desc; and vice versa.
This means that both the sort order button works as expected, and the url says what is actually going on.