### PR TITLE
Results page fixes

### DIFF
--- a/src/app/search-history.ts
+++ b/src/app/search-history.ts
@@ -89,7 +89,8 @@ export function getLatestSearchQuery() {
     let queryParams: any = { ...entry.query };
 
     if(entry.pagination) {
-      queryParams = { ...queryParams, ...entry.pagination };
+      const { page: pg, size } = entry.pagination;
+      queryParams = { ...queryParams, pg, size };
     }
 
     if(entry.sort) {

--- a/src/app/search-history/component.ts
+++ b/src/app/search-history/component.ts
@@ -38,7 +38,8 @@ export class SearchHistoryComponent implements OnInit {
     let queryParams = { ...entry.query };
 
     if(entry.pagination) {
-      queryParams = { ...queryParams, ...entry.pagination };
+      const { page: pg, size } = entry.pagination;
+      queryParams = { ...queryParams, pg, size };
     }
 
     if(entry.sort) {

--- a/src/app/search-result-list/search-result-list.component.ts
+++ b/src/app/search-result-list/search-result-list.component.ts
@@ -158,6 +158,12 @@ export class SearchResultListComponent implements OnInit {
           searchQueryParams[key] = value;
           this.searchTerms.push({ field: key, value });
         });
+
+      if(Object.keys(searchQueryParams).length < 1) {
+        this.router.navigate([ "" ]);
+        return;
+      }
+
       this.searchQueryParams = searchQueryParams;
 
       const indices = queryParamMap.get('index');

--- a/src/app/search-result-list/search-result-list.component.ts
+++ b/src/app/search-result-list/search-result-list.component.ts
@@ -205,7 +205,7 @@ export class SearchResultListComponent implements OnInit {
     totalPages = Math.min(totalPages, Math.ceil(10000 / size));
 
     // page defaults to 1
-    let page = Number(queryParamMap.get('page'));
+    let page = Number(queryParamMap.get('pg'));
     if (page < 1 || !page) {
       page = 1;
     }
@@ -288,7 +288,7 @@ export class SearchResultListComponent implements OnInit {
     return {
       ...this.queryParams,
       size: this.pagination.size,
-      page,
+      pg: page,
     };
   }
 
@@ -304,7 +304,7 @@ export class SearchResultListComponent implements OnInit {
         sortOrder: this.queryParams.sortOrder,
         sourceFilter: this.queryParams.sourceFilter,
         mode: this.modeFuzzy ? "fuzzy" : "default",
-        page: page || this.pagination.current || 1,
+        pg: page || this.pagination.current || 1,
         size: this.pagination.size,
       },
     });

--- a/src/app/search-result-list/search-result-resolver.service.ts
+++ b/src/app/search-result-list/search-result-resolver.service.ts
@@ -15,7 +15,7 @@ export class SearchResultResolverService implements Resolve<SearchResult> {
     state: RouterStateSnapshot
   ) : Observable<SearchResult> | Observable<never> {
 
-    let page: number = Number(route.queryParamMap.get('page'))
+    let page: number = Number(route.queryParamMap.get('pg'))
     if (page < 1 || page == NaN) {
       page = 1;
     }


### PR DESCRIPTION
- When navigating to /results without any valid search query params, users are now redirected back to the frontpage
- Instead of `page` we now call the query parameter for pagination `pg` so we don't trip up Wordpress (resulting in page 404s when linking to results pages).