### PR TITLE
Rewrite search key code so we always include default, and then *add* the mode key

### DIFF
--- a/src/app/elasticsearch/elasticsearch.service.ts
+++ b/src/app/elasticsearch/elasticsearch.service.ts
@@ -322,9 +322,19 @@ export class ElasticsearchService {
         return console.warn("[elasticsearch.service] key we don't know how to search on provided", queryKey);
       }
 
-      const searchKey = searchKeyConfig[mode] || searchKeyConfig.default;
+      if(searchKeyConfig.exact) {
+        must.push({
+          term: { [`person_appearance.${searchKeyConfig.exact}`]: value }
+        });
+        return;
+      }
 
-      if(searchKey) {
+      const searchKeys = [ searchKeyConfig.default ];
+      if(mode !== "default" && searchKeyConfig[mode]) {
+        searchKeys.push(searchKeyConfig[mode]);
+      }
+
+      searchKeys.forEach((searchKey) => {
         if(/[\?\*]/.test(value)) {
           must.push({
             wildcard: { [`person_appearance.${searchKey}`]: value }
@@ -336,13 +346,7 @@ export class ElasticsearchService {
           match: { [`person_appearance.${searchKey}`]: value }
         });
         return;
-      }
-
-      if(searchKeyConfig.exact) {
-        must.push({
-          term: { [`person_appearance.${searchKeyConfig.exact}`]: value }
-        });
-      }
+      });
     });
 
     if(sourceFilter.length) {

--- a/src/app/elasticsearch/elasticsearch.service.ts
+++ b/src/app/elasticsearch/elasticsearch.service.ts
@@ -334,19 +334,20 @@ export class ElasticsearchService {
         searchKeys.push(searchKeyConfig[mode]);
       }
 
-      searchKeys.forEach((searchKey) => {
+      const searchKeyQuery = searchKeys.map((searchKey) => {
         if(/[\?\*]/.test(value)) {
-          must.push({
-            wildcard: { [`person_appearance.${searchKey}`]: value }
-          });
-          return;
+          return { wildcard: { [`person_appearance.${searchKey}`]: value } };
         }
 
-        must.push({
-          match: { [`person_appearance.${searchKey}`]: value }
-        });
-        return;
+        return { match: { [`person_appearance.${searchKey}`]: value } };
       });
+
+      if(searchKeyQuery.length == 1) {
+        must.push(searchKeyQuery[0]);
+        return;
+      }
+
+      must.push({ bool: { should: searchKeyQuery } });
     });
 
     if(sourceFilter.length) {

--- a/src/app/search-history.ts
+++ b/src/app/search-history.ts
@@ -29,6 +29,7 @@ export interface SearchHistoryEntry {
   timestamp?: Date,
   pagination?: SearchResultPagination,
   sort?: SearchResultSorting,
+  mode?: string,
 }
 
 export interface LifecourseSearchHistoryEntry {
@@ -103,6 +104,10 @@ export function getLatestSearchQuery() {
           .map(({ event_type, source_year }) => `${event_type}_${source_year}`)
           .join(",")
       };
+    }
+
+    if(entry.mode) {
+      queryParams.mode = entry.mode;
     }
 
     if(Array.isArray(entry.index)) {

--- a/src/app/search-history/component.ts
+++ b/src/app/search-history/component.ts
@@ -54,6 +54,10 @@ export class SearchHistoryComponent implements OnInit {
       };
     }
 
+    if(entry.mode) {
+      queryParams.mode = entry.mode;
+    }
+
     if(Array.isArray(entry.index)) {
       queryParams.index = entry.index.join(",");
     }

--- a/src/app/search-result-list/search-result-resolver.service.ts
+++ b/src/app/search-result-list/search-result-resolver.service.ts
@@ -79,6 +79,7 @@ export class SearchResultResolverService implements Resolve<SearchResult> {
       index,
       pagination: { page, size },
       sort: { sortBy, sortOrder },
+      mode,
     });
 
     return this.service.advancedSearch(actualSearchTerms, index, (page - 1) * size, size, sortBy, sortOrder, sourceFilter, mode);


### PR DESCRIPTION
(Right now, the _fz fields in the db do not include the values in the non-_fz fields in the db, so this ensures fuzzy always gets *more* results.)

Early out on exact keys, instead of having them as a trailing check.