### PR TITLE
Enable fuzziness on `match` queries, increase fuzz expansions so we hit more cases!

### DIFF
--- a/src/app/elasticsearch/elasticsearch.service.ts
+++ b/src/app/elasticsearch/elasticsearch.service.ts
@@ -327,13 +327,24 @@ export class ElasticsearchService {
       if(searchKey) {
         if(/[\?\*]/.test(value)) {
           must.push({
-            wildcard: { [`person_appearance.${searchKey}`]: value }
+            wildcard: {
+              [`person_appearance.${searchKey}`]: {
+                value: value,
+              }
+            }
           });
           return;
         }
 
         must.push({
-          match: { [`person_appearance.${searchKey}`]: value }
+          match: {
+            [`person_appearance.${searchKey}`]: {
+              query: value,
+              fuzziness: "AUTO",
+              max_expansions: 250,
+              operator: "AND"
+            }
+          }
         });
         return;
       }


### PR DESCRIPTION
max_expansions defaults to 50, 250 allows matches on e.g. Aalborg->Ålborg

also default operator is OR but we want AND, so if you include several names in last name, you only get results that match all of them