### PR TITLE
Phrase search

### DIFF
--- a/src/app/elasticsearch/elasticsearch.service.ts
+++ b/src/app/elasticsearch/elasticsearch.service.ts
@@ -436,12 +436,19 @@ export class ElasticsearchService {
       })
     }
 
+    const simplifiedQueryFromMust = (must) => {
+      if(must.length == 1) {
+        return must[0];
+      }
+      return {
+        bool: { must },
+      };
+    };
+
     const getFullPersonAppearanceQueryFromMustQuery = (must) => ({
       nested: {
         path: "person_appearance",
-        query: {
-          bool: { must },
-        },
+        query: simplifiedQueryFromMust(must),
         score_mode: "max",
       },
     });

--- a/src/app/elasticsearch/elasticsearch.service.ts
+++ b/src/app/elasticsearch/elasticsearch.service.ts
@@ -382,17 +382,19 @@ export class ElasticsearchService {
           }
         });
 
-        must.push({
-          match: {
-            [`person_appearance.${searchKey}`]: {
-              // Match query splits into terms on space, so we can simplify the query here
-              query: nonWildcardTerms.join(" "),
-              fuzziness: "AUTO",
-              max_expansions: 250,
-              operator: "AND"
+        if(nonWildcardTerms.length) {
+          must.push({
+            match: {
+              [`person_appearance.${searchKey}`]: {
+                // Match query splits into terms on space, so we can simplify the query here
+                query: nonWildcardTerms.join(" "),
+                fuzziness: "AUTO",
+                max_expansions: 250,
+                operator: "AND"
+              }
             }
-          }
-        });
+          });
+        }
       }
     });
 

--- a/src/app/elasticsearch/elasticsearch.service.ts
+++ b/src/app/elasticsearch/elasticsearch.service.ts
@@ -301,7 +301,7 @@ export class ElasticsearchService {
     let sourceLookupFilter = must;
 
     Object.keys(query).filter((queryKey) => query[queryKey]).forEach((queryKey) => {
-      const value = query[queryKey];
+      let value = query[queryKey];
 
       // Special case: query
       if(queryKey === "query") {
@@ -334,6 +334,41 @@ export class ElasticsearchService {
             }
           });
           return;
+        }
+
+        if(value.includes('"')) {
+          const parts = value.split('"');
+
+          console.log("val", value, value.includes('"'), value.split('"'), parts.length, parts.length % 2);
+
+          // If there are less than 3 parts, there is only one quotation mark
+          // Likewise, the number of parts must be uneven if there is an even number of quotation marks
+          if(parts.length >= 3 && parts.length % 2 == 1) {
+            // Quoted parts are every other part starting at index 1
+            const quoted = parts.filter((_, i) => i % 2 == 1);
+
+            // Unquoted parts are the opposite
+            const unquoted = parts.filter((_, i) => i % 2 == 0);
+
+            console.log("Q", quoted, unquoted);
+
+            quoted.forEach((quotedValue) => {
+              must.push({
+                match_phrase: {
+                  [`person_appearance.${searchKey}`]: {
+                    query: quotedValue,
+                  },
+                },
+              });
+            });
+
+            // We send the unquoted parts back to normal value handling.
+            // If there are none, we don't need to continue.
+            value = unquoted.join(" ").trim();
+            if(!value) {
+              return;
+            }
+          }
         }
 
         must.push({

--- a/src/app/elasticsearch/elasticsearch.service.ts
+++ b/src/app/elasticsearch/elasticsearch.service.ts
@@ -339,8 +339,6 @@ export class ElasticsearchService {
         if(value.includes('"')) {
           const parts = value.split('"');
 
-          console.log("val", value, value.includes('"'), value.split('"'), parts.length, parts.length % 2);
-
           // If there are less than 3 parts, there is only one quotation mark
           // Likewise, the number of parts must be uneven if there is an even number of quotation marks
           if(parts.length >= 3 && parts.length % 2 == 1) {

--- a/src/app/elasticsearch/elasticsearch.service.ts
+++ b/src/app/elasticsearch/elasticsearch.service.ts
@@ -365,6 +365,15 @@ export class ElasticsearchService {
           }
         }
 
+        if(!value) {
+          // Everything was quoted
+          if(searchKeySubQuery.length > 1) {
+            return { bool: { must: searchKeySubQuery } };
+          }
+
+          return searchKeySubQuery[0];
+        }
+
         const terms = value.split(/\s+/g);
         const wildcardTerms = terms.filter((value) => /[\?\*]/.test(value));
         const nonWildcardTerms = terms.filter((value) => !/[\?\*]/.test(value));

--- a/src/app/elasticsearch/elasticsearch.service.ts
+++ b/src/app/elasticsearch/elasticsearch.service.ts
@@ -362,9 +362,6 @@ export class ElasticsearchService {
             // We send the unquoted parts back to normal value handling.
             // If there are none, we don't need to continue.
             value = unquoted.join(" ").trim();
-            if(!value) {
-              return;
-            }
           }
         }
 

--- a/src/app/elasticsearch/elasticsearch.service.ts
+++ b/src/app/elasticsearch/elasticsearch.service.ts
@@ -349,8 +349,6 @@ export class ElasticsearchService {
             // Unquoted parts are the opposite
             const unquoted = parts.filter((_, i) => i % 2 == 0);
 
-            console.log("Q", quoted, unquoted);
-
             quoted.forEach((quotedValue) => {
               searchKeySubQuery.push({
                 match_phrase: {
@@ -397,8 +395,6 @@ export class ElasticsearchService {
             }
           });
         }
-
-        console.log("searchKeySubQuery", searchKeySubQuery);
 
         if(searchKeySubQuery.length > 1) {
           return { bool: { must: searchKeySubQuery } };


### PR DESCRIPTION
Based on #121 

Uafklaret: skal denne merges as-is, for den virker ikke vildt godt sådan som indekset er sat op lige nu?

Derudover: skal den også virke for fritekstsøgning og søgninger med wildcards? F.eks. ved også at splitte wildcard søgninger op i flere queries hvis ikke der er quotes omkring dem

E.g. `"J?ns N?els"` bliver til én wildcard søgning, men `J?ns N?els` bliver til to, én på `J?ns` og én på `N?ls`.

Og lignende for fritekstsøgninger: skal vi trække ting i quotes ud? Kan vi overhovedet det med simple_query_string?