### PR TITLE
Draft: Specify fields on fritekst query based on mode

### DIFF
--- a/src/app/elasticsearch/elasticsearch.service.ts
+++ b/src/app/elasticsearch/elasticsearch.service.ts
@@ -305,10 +305,15 @@ export class ElasticsearchService {
 
       // Special case: query
       if(queryKey === "query") {
+        const fields = ["*_searchable"];
+        if(mode === "fuzzy") {
+          fields.push("*_searchable_fz");
+        }
+
         must.push({
           simple_query_string: {
             query: value,
-            fields: ["*"],
+            fields,
             default_operator: "and",
             analyze_wildcard: true,
           },

--- a/src/app/elasticsearch/elasticsearch.service.ts
+++ b/src/app/elasticsearch/elasticsearch.service.ts
@@ -312,11 +312,27 @@ export class ElasticsearchService {
 
       // Special case: query
       if(queryKey === "query") {
-        const fields = ["*_searchable"];
-        if(mode === "fuzzy") {
-          fields.push("*_searchable_fz");
-        }
+        // only string fields
+        let fields = [
+          "*name_searchable",
+          "*lastname_searchable",
+          "*firstnames_searchable",
+          "*birthplace_searchable",
+          "*sourceplace_searchable",
+          "*gender_searchable",
+          "*birthname_searchable",
+        ];
 
+        if(mode === "fuzzy") {
+          const fuzzyStringFields = [
+            "*name_searchable_fz",
+            "*lastname_searchable_fz",
+            "*firstnames_searchable_fz",
+            "*birthplace_searchable_fz",
+            "*birthname_searchable_fz",
+          ];
+          fields = fields.concat(fuzzyStringFields);
+        }
         must.push({
           simple_query_string: {
             query: value,


### PR DESCRIPTION
Uafklaret - afventer afklaring af hvorfor elasticsearch ikke kan håndtere de nye queries hvor `fields` ikke er `["*"]`.