### PR TITLE
Adds related pas for source type PR / Kirkebog

### DIFF
--- a/src/app/person-appearance/person-appearance-resolver.service.ts
+++ b/src/app/person-appearance/person-appearance-resolver.service.ts
@@ -44,6 +44,22 @@ export class PersonAppearanceResolverService implements Resolve<PersonAppearance
           });
         }
 
+        const matchList: Object[] = [
+          { "match": { "person_appearance.source_id": pa.source_id } },
+        ];
+
+        // we will only have either hh_id OR event_id
+        if(pa.hh_id) {
+          matchList.push(
+            { "match": { "person_appearance.hh_id": pa.hh_id } },
+          )
+        }
+        if(pa.event_id) {
+          matchList.push(
+            { "match": { "person_appearance.event_id": pa.event_id } },
+          )
+        }
+
         let body = {
           "from": 0,
           "size": 100,
@@ -55,11 +71,7 @@ export class PersonAppearanceResolverService implements Resolve<PersonAppearance
                     "path": "person_appearance",
                     "query": {
                       "bool" : {
-                        "must": [
-                          { "match": { "person_appearance.hh_id": pa.hh_id } },
-                          { "match": { "person_appearance.event_id": pa.event_id } },
-                          { "match": { "person_appearance.source_id": pa.source_id } },
-                        ]
+                        "must": matchList
                       }
                     }
                   }
@@ -68,10 +80,6 @@ export class PersonAppearanceResolverService implements Resolve<PersonAppearance
             }
           }
         }
-        // remove hh_id or event_id if they are undefined.
-        // we will never have both of them set, so we will always filter out one of them.
-        body.query.bool.must[0].nested.query.bool.must = body.query.bool.must[0].nested.query.bool.must
-          .filter((match) => !Object.values(match.match).some(value => value == undefined));
 
         return this.elasticsearch.search(['pas'], body).pipe(
           map((searchResult, index) => {

--- a/src/app/search/search.service.ts
+++ b/src/app/search/search.service.ts
@@ -64,6 +64,8 @@ export interface PersonAppearance {
   dateOfDeath: string,
   deathyear_display: string,
   district: string,
+  event_id: number,
+  event_persons: number,
   event_type: string,
   event_type_display: string,
   event_year: string,


### PR DESCRIPTION
Pr have fields event_id and event_persons to indicate related person_appearances.

right now I have simply modified the code in the person appearance a bit to store the related persons in the hh field.

At some point we should maybe rename the hh field, as this is more of a 'all kind of related persons field' than a 'hh/ household' field.