### PR TITLE
Simplify elastic search query for fuzzy search

### DIFF
--- a/src/app/elasticsearch/elasticsearch.service.ts
+++ b/src/app/elasticsearch/elasticsearch.service.ts
@@ -336,12 +336,9 @@ export class ElasticsearchService {
         return;
       }
 
-      const searchKeys = [ searchKeyConfig.default ];
-      if(mode !== "default" && searchKeyConfig[mode]) {
-        searchKeys.push(searchKeyConfig[mode]);
-      }
+      const searchKey = searchKeyConfig[mode];
 
-      const searchKeyQuery = searchKeys.map((searchKey) => {
+      const getSearchKeyQuery = (searchKey, value) => {
         const searchKeySubQuery = [];
 
         if(value.includes('"')) {
@@ -417,14 +414,10 @@ export class ElasticsearchService {
         }
 
         return searchKeySubQuery[0];
-      });
-
-      if(searchKeyQuery.length == 1) {
-        must.push(searchKeyQuery[0]);
-        return;
       }
 
-      must.push({ bool: { should: searchKeyQuery } });
+      const searchKeyQuery = getSearchKeyQuery(searchKey, value);
+      must.push(searchKeyQuery);
     });
 
     if(sourceFilter.length) {

--- a/src/app/search-term-values.ts
+++ b/src/app/search-term-values.ts
@@ -19,13 +19,15 @@ export const mapSearchKeys = {
   },
   sourcePlace: {
     default: "sourceplace_searchable",
+    fuzzy: "sourceplace_searchable",
   },
   birthYear: {
     default: "birthyear_searchable",
     fuzzy: "birthyear_searchable_fz",
   },
   sourceYear: {
-    default: "source_year_agg"
+    default: "source_year_searchable",
+    fuzzy: "source_year_searchable_fz",
   },
   deathYear: {
     default: "deathyear_searchable",


### PR DESCRIPTION
Now the default values (the *_searchable field values) have been added to the *_searchable_fz fields. This way we only need to search the _searchable_fz field when fuzzy search. 