### PR TITLE
Remove fuzziness param from elastic search query

### DIFF
--- a/src/app/elasticsearch/elasticsearch.service.ts
+++ b/src/app/elasticsearch/elasticsearch.service.ts
@@ -398,9 +398,6 @@ export class ElasticsearchService {
               [`person_appearance.${searchKey}`]: {
                 // Match query splits into terms on space, so we can simplify the query here
                 query: nonWildcardTerms.join(" "),
-
-                // Fuzziness disabled for now, until we figure out how exactly we want it to work
-                fuzziness: 0, //"AUTO",
                 //max_expansions: 250,
 
                 operator: "AND"


### PR DESCRIPTION
remove fuzziness param from elastic search query now we have decided not to use the built-in elastic-search fuzzy functionality.

Instead we have made fields for fuzzy search that we can make regular searches on.

Having the fuzzy param made searches on integers fail (namely search on source_year