### PR TITLE
Adds Source filter options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8234,6 +8234,11 @@
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "dev": true
     },
+    "lodash.groupby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
+      "integrity": "sha1-Cwih3PaDl8OXhVwyOXg4Mt90A9E="
+    },
     "lodash.isequal": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@angular/router": "^9.1.4",
     "bootstrap": "^4.4.1",
     "font-awesome": "^4.7.0",
+    "lodash.groupby": "^4.6.0",
     "lodash.isequal": "^4.5.0",
     "rxjs": "~6.5.4",
     "tslib": "^1.10.0",

--- a/src/app/display-helpers.ts
+++ b/src/app/display-helpers.ts
@@ -28,6 +28,12 @@ export function eventIcon(eventType: string) {
   }[eventType] || "circle";
 };
 
+export function sourceIcon(sourceType: string) {
+  return {
+    "census": "archive",
+  }[sourceType] || "circle";
+};
+
 export function prettyDate(rawDate) {
   const months = [
     "januar",

--- a/src/app/elasticsearch/elasticsearch.service.ts
+++ b/src/app/elasticsearch/elasticsearch.service.ts
@@ -67,7 +67,6 @@ export interface ElasticSourceLookupResult {
       sources: {
         buckets: {
           key: {
-            source_year_display: string,
             source_type_wp4: string
             source_type_display: string // only used for displaying
           },
@@ -83,7 +82,6 @@ export interface ElasticEventLookupResult {
       sources: {
         buckets: {
           key: {
-            event_year_display: string,
             event_type: string
             event_type_display: string // only used for displaying
           },
@@ -304,12 +302,10 @@ export class ElasticsearchService {
 
     const sources = {
       eventType: [
-          { event_year_display: { terms: { field: "person_appearance.event_year_display" } } },
           { event_type: { terms: { field: "person_appearance.event_type" } } },
           { event_type_display: { terms: { field: "person_appearance.event_type_display" } } },
         ],
       source: [
-          { source_year_display: { terms: { field: "person_appearance.source_year_display" } } },
           { source_type_wp4: { terms: { field: "person_appearance.source_type_wp4" } } },
           { source_type_display: { terms: { field: "person_appearance.source_type_display" } } },
         ],
@@ -463,11 +459,10 @@ export class ElasticsearchService {
       const filtersGroupedByFilterType = groupBy(sourceFilter, 'filter_type');
 
       const eventTypeFilters = (filtersGroupedByFilterType) => {
-        return filtersGroupedByFilterType['eventType'].map(({ event_year_display, event_type, event_type_display }) => {
+        return filtersGroupedByFilterType['eventType'].map(({ event_type, event_type_display }) => {
           return {
             bool: {
               must: [
-                { match: { [`person_appearance.event_year_display`]: event_year_display } },
                 { match: { [`person_appearance.event_type`]: event_type } },
                 { match: { [`person_appearance.event_type_display`]: event_type_display } },
               ]
@@ -477,11 +472,10 @@ export class ElasticsearchService {
       }
 
       const sourceTypeFilters = (filtersGroupedByFilterType) => {
-        return filtersGroupedByFilterType['source'].map(({ source_year_display, source_type_wp4, source_type_display }) => {
+        return filtersGroupedByFilterType['source'].map(({ source_type_wp4, source_type_display }) => {
           return {
             bool: {
               must: [
-                { match: { [`person_appearance.source_year_display`]: source_year_display } },
                 { match: { [`person_appearance.source_type_wp4`]: source_type_wp4 } },
                 { match: { [`person_appearance.source_type_display`]: source_type_display } },
               ]

--- a/src/app/elasticsearch/elasticsearch.service.ts
+++ b/src/app/elasticsearch/elasticsearch.service.ts
@@ -145,7 +145,7 @@ export class ElasticsearchService {
       indexHits: {},
       hits: [],
       meta: {
-        possibleSources: sourceLookupResult?.aggregations?.person_appearance?.sources?.buckets.map((bucket) => ({ ...bucket.key, count: bucket.doc_count })) ?? [],
+        possibleFilters: sourceLookupResult?.aggregations?.person_appearance?.sources?.buckets.map((bucket) => ({ ...bucket.key, count: bucket.doc_count })) ?? [],
       },
     };
 
@@ -239,7 +239,7 @@ export class ElasticsearchService {
           totalHits: 0,
           indexHits: {},
           hits: [],
-          meta: { possibleSources: [] },
+          meta: { possibleFilters: [] },
         });
 
         observer.complete();

--- a/src/app/filter-sidebar/component.ts
+++ b/src/app/filter-sidebar/component.ts
@@ -26,8 +26,8 @@ export interface Option {
 export class FilterSidebar implements OnInit {
   @Input() featherIconPath: string;
   @Input() possibleFilters: {
-    eventType: Array<{ event_year_display: string, event_type: string, event_type_display: string, count: number }>,
-    source: Array<{ source_year_display: string, source_type_wp4: string, source_type_display: string, count: number }>
+    eventType: Array<{ event_type: string, event_type_display: string, count: number }>,
+    source: Array<{ source_type_wp4: string, source_type_display: string, count: number }>
   };
   @Input() openSidebar: boolean;
   @Input()
@@ -60,11 +60,13 @@ export class FilterSidebar implements OnInit {
 
   filtersWithLabels = [];
   sidebarCategoryOpen: {
-    source: String,
-    eventType: String,
+    source: Boolean,
+    eventType: Boolean,
+    year: Boolean,
   } = {
-    source: "",
-    eventType: "",
+    source: false,
+    eventType: false,
+    year: false,
   };
 
   _filters: number[] = [];
@@ -72,47 +74,31 @@ export class FilterSidebar implements OnInit {
   onTouched: Function = () => {};
 
   sourceCategories(filterType) {
-    const result = {};
-    this.possibleFilters[filterType].forEach(x => {
-      const filter =  {
-        label: `${x.source_type_display} ${x.source_year_display}`,
+    const sourceCategories = this.possibleFilters[filterType].map(x => {
+      return {
+        label: x.source_type_display,
         type: x.source_type_wp4,
         icon: sourceIcon(x.source_type_wp4),
-        value: `${filterType}_${x.source_type_wp4}_${x.source_type_display}_${x.source_year_display}`,
+        value: `${filterType}_${x.source_type_wp4}_${x.source_type_display}`,
         count: prettyNumbers(x.count),
         chosen: false,
       };
-      if(!result[x.source_type_wp4]) {
-        result[x.source_type_wp4] = {
-          display: x.source_type_display,
-          filters: [],
-        }
-      }
-      result[x.source_type_wp4].filters.push(filter);
     });
-    return result;
+    return sourceCategories;
   }
 
   eventCategories(filterType) {
-    const result = {};
-    this.possibleFilters[filterType].forEach(x => {
-      const filter =  {
-        label: `${x.event_type_display} ${x.event_year_display}`,
+    const eventCategories = this.possibleFilters[filterType].map(x => {
+      return {
+        label: x.event_type_display,
         type: x.event_type,
         icon: eventIcon(x.event_type),
-        value: `${filterType}_${x.event_type}_${x.event_type_display}_${x.event_year_display}`,
+        value: `${filterType}_${x.event_type}_${x.event_type_display}`,
         count: prettyNumbers(x.count),
         chosen: false,
       };
-      if(!result[x.event_type]) {
-        result[x.event_type] = {
-          display: x.event_type_display,
-          filters: [],
-        }
-      }
-      result[x.event_type].filters.push(filter);
     });
-    return result;
+    return eventCategories;
   }
 
   filtersCategories(filterType) {
@@ -144,8 +130,8 @@ export class FilterSidebar implements OnInit {
     return this.filters.some((filterValue) => filterValue === optionValue);
   }
 
-  toggleCategory(filter, type) {
-    this.sidebarCategoryOpen[filter] = type;
+  toggleCategory(filterType) {
+    this.sidebarCategoryOpen[filterType] = !this.sidebarCategoryOpen[filterType];
   }
 
   closeOnEsc() {

--- a/src/app/filter-sidebar/component.ts
+++ b/src/app/filter-sidebar/component.ts
@@ -25,7 +25,7 @@ export interface Option {
 
 export class FilterSidebar implements OnInit {
   @Input() featherIconPath: string;
-  @Input() possibleSources: Array<{ event_year_display: string, event_type: string, event_type_display: string, count: number }>;
+  @Input() possibleSources: {eventType: Array<{ filter_type: string, event_year_display: string, event_type: string, event_type_display: string, count: number }>};
   @Input() openSidebar: boolean;
   @Input()
   get filters() {
@@ -60,15 +60,14 @@ export class FilterSidebar implements OnInit {
   onChange: Function = () => {};
   onTouched: Function = () => {};
 
-  get filtersCategories() {
+  filtersCategories(filterType) {
     const result = {};
-
-    this.possibleSources.forEach(x => {
+    this.possibleSources[filterType].forEach(x => {
       const filter =  {
         label: `${x.event_type_display} ${x.event_year_display}`,
         type: x.event_type,
         icon: eventIcon(x.event_type),
-        value: `${x.event_type}_${x.event_type_display}_${x.event_year_display}`,
+        value: `${filterType}_${x.event_type}_${x.event_type_display}_${x.event_year_display}`,
         count: prettyNumbers(x.count),
         chosen: false,
       };

--- a/src/app/filter-sidebar/component.ts
+++ b/src/app/filter-sidebar/component.ts
@@ -59,7 +59,14 @@ export class FilterSidebar implements OnInit {
   // End ControlValueAccessor
 
   filtersWithLabels = [];
-  sidebarCategoryOpen: String = undefined;
+  sidebarCategoryOpen: {
+    source: String,
+    eventType: String,
+  } = {
+    source: "",
+    eventType: "",
+  };
+
   _filters: number[] = [];
   onChange: Function = () => {};
   onTouched: Function = () => {};
@@ -137,8 +144,8 @@ export class FilterSidebar implements OnInit {
     return this.filters.some((filterValue) => filterValue === optionValue);
   }
 
-  toggleCategory(type) {
-    this.sidebarCategoryOpen = type;
+  toggleCategory(filter, type) {
+    this.sidebarCategoryOpen[filter] = type;
   }
 
   closeOnEsc() {

--- a/src/app/filter-sidebar/component.ts
+++ b/src/app/filter-sidebar/component.ts
@@ -25,7 +25,7 @@ export interface Option {
 
 export class FilterSidebar implements OnInit {
   @Input() featherIconPath: string;
-  @Input() possibleSources: {eventType: Array<{ filter_type: string, event_year_display: string, event_type: string, event_type_display: string, count: number }>};
+  @Input() possibleFilters: {eventType: Array<{ filter_type: string, event_year_display: string, event_type: string, event_type_display: string, count: number }>};
   @Input() openSidebar: boolean;
   @Input()
   get filters() {
@@ -62,7 +62,7 @@ export class FilterSidebar implements OnInit {
 
   filtersCategories(filterType) {
     const result = {};
-    this.possibleSources[filterType].forEach(x => {
+    this.possibleFilters[filterType].forEach(x => {
       const filter =  {
         label: `${x.event_type_display} ${x.event_year_display}`,
         type: x.event_type,

--- a/src/app/filter-sidebar/component.ts
+++ b/src/app/filter-sidebar/component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, EventEmitter, forwardRef, Input, Output } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
-import { eventIcon, eventType, prettyNumbers } from '../display-helpers';
+import { eventIcon, sourceIcon, eventType, prettyNumbers } from '../display-helpers';
 
 export interface Option {
   label: string;
@@ -25,7 +25,10 @@ export interface Option {
 
 export class FilterSidebar implements OnInit {
   @Input() featherIconPath: string;
-  @Input() possibleFilters: {eventType: Array<{ filter_type: string, event_year_display: string, event_type: string, event_type_display: string, count: number }>};
+  @Input() possibleFilters: {
+    eventType: Array<{ event_year_display: string, event_type: string, event_type_display: string, count: number }>,
+    source: Array<{ source_year_display: string, source_type_wp4: string, source_type_display: string, count: number }>
+  };
   @Input() openSidebar: boolean;
   @Input()
   get filters() {
@@ -38,6 +41,7 @@ export class FilterSidebar implements OnInit {
   @Output() closeSidebar: EventEmitter<any> = new EventEmitter();
   @Output() removeFilter: EventEmitter<any> = new EventEmitter();
   eventIcon = eventIcon;
+  sourceIcon = sourceIcon;
   eventType = eventType;
 
   // Start ControlValueAccessor
@@ -60,7 +64,29 @@ export class FilterSidebar implements OnInit {
   onChange: Function = () => {};
   onTouched: Function = () => {};
 
-  filtersCategories(filterType) {
+  sourceCategories(filterType) {
+    const result = {};
+    this.possibleFilters[filterType].forEach(x => {
+      const filter =  {
+        label: `${x.source_type_display} ${x.source_year_display}`,
+        type: x.source_type_wp4,
+        icon: sourceIcon(x.source_type_wp4),
+        value: `${filterType}_${x.source_type_wp4}_${x.source_type_display}_${x.source_year_display}`,
+        count: prettyNumbers(x.count),
+        chosen: false,
+      };
+      if(!result[x.source_type_wp4]) {
+        result[x.source_type_wp4] = {
+          display: x.source_type_display,
+          filters: [],
+        }
+      }
+      result[x.source_type_wp4].filters.push(filter);
+    });
+    return result;
+  }
+
+  eventCategories(filterType) {
     const result = {};
     this.possibleFilters[filterType].forEach(x => {
       const filter =  {
@@ -80,6 +106,15 @@ export class FilterSidebar implements OnInit {
       result[x.event_type].filters.push(filter);
     });
     return result;
+  }
+
+  filtersCategories(filterType) {
+    if(filterType == 'eventType') {
+      return this.eventCategories(filterType);
+    }
+    if(filterType == 'source') {
+      return this.sourceCategories(filterType);
+    }
   }
 
   close() {

--- a/src/app/filter-sidebar/view.html
+++ b/src/app/filter-sidebar/view.html
@@ -17,6 +17,57 @@
     </button>
   </div>
   <div class="lls-sidebar__subheader">
+    <h4>Kilder</h4>
+  </div>
+  <div class="lls-filter-sidebar__options">
+    <button
+      *ngIf="sidebarCategoryOpen"
+      class="lls-filter-sidebar__option lls-sidebar__item"
+      [tabindex]="openSidebar ? 0 : -1"
+      (click)="toggleCategory('')"
+    >
+    <svg class="lls-filter-sidebar__option-icon lls-icon">
+      <use [attr.href]="featherIconPath + '#arrow-left'"></use>
+    </svg>
+      Tilbage
+    </button>
+    <ng-container *ngFor="let category of filtersCategories('source') | keyvalue">
+      <ng-container *ngIf="!sidebarCategoryOpen">
+        <button
+          class="lls-filter-sidebar__option lls-sidebar__item"
+          [tabindex]="openSidebar ? 0 : -1"
+          (click)="toggleCategory(category.key)"
+         >
+          <svg class="lls-icon lls-icon--left u-mr-2">
+            <use [attr.href]="featherIconPath + '#' + sourceIcon(category.key)"></use>
+          </svg>
+          {{ category.value.display }}
+          <span class="lls-filter-sidebar__option-count">{{'\u00A0'}} ({{ filtersCategories('source')[category.key].filters.length }})</span>
+          <svg class="lls-filter-sidebar__option-icon lls-filter-sidebar__option-item--right lls-icon">
+            <use [attr.href]="featherIconPath + '#arrow-right'"></use>
+          </svg>
+        </button>
+      </ng-container>
+      <ng-container *ngIf="sidebarCategoryOpen === category.key">
+        <button
+          *ngFor="let option of category.value.filters, index as i"
+          class="lls-filter-sidebar__option lls-sidebar__item"
+          [class]="activeFilter(option.value) ? 'lls-filter-sidebar__option--active' : ''"
+          [tabindex]="openSidebar ? 0 : -1"
+          (click)="addFilter(option)"
+        >
+          <svg class="lls-icon lls-icon--left u-mr-2">
+            <use [attr.href]="featherIconPath + '#' + (activeFilter(option.value) ? 'check-square' : 'square')"></use>
+          </svg>
+          {{ option.label }}
+          <span class="lls-filter-sidebar__option-count lls-filter-sidebar__option-item--right">
+            {{ option.count }}
+          </span>
+        </button>
+      </ng-container>
+    </ng-container>
+  </div>
+  <div class="lls-sidebar__subheader">
     <h4>Hændelser</h4>
   </div>
   <div class="lls-filter-sidebar__options">

--- a/src/app/filter-sidebar/view.html
+++ b/src/app/filter-sidebar/view.html
@@ -21,10 +21,10 @@
   </div>
   <div class="lls-filter-sidebar__options">
     <button
-      *ngIf="sidebarCategoryOpen"
+      *ngIf="sidebarCategoryOpen['source']"
       class="lls-filter-sidebar__option lls-sidebar__item"
       [tabindex]="openSidebar ? 0 : -1"
-      (click)="toggleCategory('')"
+      (click)="toggleCategory('source', '')"
     >
     <svg class="lls-filter-sidebar__option-icon lls-icon">
       <use [attr.href]="featherIconPath + '#arrow-left'"></use>
@@ -32,11 +32,11 @@
       Tilbage
     </button>
     <ng-container *ngFor="let category of filtersCategories('source') | keyvalue">
-      <ng-container *ngIf="!sidebarCategoryOpen">
+      <ng-container *ngIf="!sidebarCategoryOpen['source']">
         <button
           class="lls-filter-sidebar__option lls-sidebar__item"
           [tabindex]="openSidebar ? 0 : -1"
-          (click)="toggleCategory(category.key)"
+          (click)="toggleCategory('source', category.key)"
          >
           <svg class="lls-icon lls-icon--left u-mr-2">
             <use [attr.href]="featherIconPath + '#' + sourceIcon(category.key)"></use>
@@ -48,7 +48,7 @@
           </svg>
         </button>
       </ng-container>
-      <ng-container *ngIf="sidebarCategoryOpen === category.key">
+      <ng-container *ngIf="sidebarCategoryOpen['source'] === category.key">
         <button
           *ngFor="let option of category.value.filters, index as i"
           class="lls-filter-sidebar__option lls-sidebar__item"
@@ -72,10 +72,10 @@
   </div>
   <div class="lls-filter-sidebar__options">
     <button
-      *ngIf="sidebarCategoryOpen"
+      *ngIf="sidebarCategoryOpen['eventType']"
       class="lls-filter-sidebar__option lls-sidebar__item"
       [tabindex]="openSidebar ? 0 : -1"
-      (click)="toggleCategory('')"
+      (click)="toggleCategory('eventType', '')"
     >
     <svg class="lls-filter-sidebar__option-icon lls-icon">
       <use [attr.href]="featherIconPath + '#arrow-left'"></use>
@@ -83,12 +83,12 @@
       Tilbage
     </button>
     <ng-container *ngFor="let category of filtersCategories('eventType') | keyvalue">
-      <ng-container *ngIf="!sidebarCategoryOpen">
+      <ng-container *ngIf="!sidebarCategoryOpen['eventType']">
         <button
           class="lls-filter-sidebar__option lls-sidebar__item"
           [tabindex]="openSidebar ? 0 : -1"
-          (click)="toggleCategory(category.key)"
-         >
+          (click)="toggleCategory('eventType', category.key)"
+        >
           <svg class="lls-icon lls-icon--left u-mr-2">
             <use [attr.href]="featherIconPath + '#' + eventIcon(category.key)"></use>
           </svg>
@@ -99,7 +99,7 @@
           </svg>
         </button>
       </ng-container>
-      <ng-container *ngIf="sidebarCategoryOpen === category.key">
+      <ng-container *ngIf="sidebarCategoryOpen['eventType'] === category.key">
         <button
           *ngFor="let option of category.value.filters, index as i"
           class="lls-filter-sidebar__option lls-sidebar__item"

--- a/src/app/filter-sidebar/view.html
+++ b/src/app/filter-sidebar/view.html
@@ -16,106 +16,110 @@
       </svg>
     </button>
   </div>
-  <div class="lls-sidebar__subheader">
-    <h4>Kilder</h4>
-  </div>
-  <div class="lls-filter-sidebar__options">
-    <button
-      *ngIf="sidebarCategoryOpen['source']"
-      class="lls-filter-sidebar__option lls-sidebar__item"
-      [tabindex]="openSidebar ? 0 : -1"
-      (click)="toggleCategory('source', '')"
-    >
-    <svg class="lls-filter-sidebar__option-icon lls-icon">
-      <use [attr.href]="featherIconPath + '#arrow-left'"></use>
-    </svg>
-      Tilbage
-    </button>
-    <ng-container *ngFor="let category of filtersCategories('source') | keyvalue">
-      <ng-container *ngIf="!sidebarCategoryOpen['source']">
-        <button
-          class="lls-filter-sidebar__option lls-sidebar__item"
-          [tabindex]="openSidebar ? 0 : -1"
-          (click)="toggleCategory('source', category.key)"
-         >
-          <svg class="lls-icon lls-icon--left u-mr-2">
-            <use [attr.href]="featherIconPath + '#' + sourceIcon(category.key)"></use>
-          </svg>
-          {{ category.value.display }}
-          <span class="lls-filter-sidebar__option-count">{{'\u00A0'}} ({{ filtersCategories('source')[category.key].filters.length }})</span>
-          <svg class="lls-filter-sidebar__option-icon lls-filter-sidebar__option-item--right lls-icon">
-            <use [attr.href]="featherIconPath + '#arrow-right'"></use>
-          </svg>
-        </button>
+  <ng-container *ngIf="!sidebarCategoryOpen['eventType']">
+    <div class="lls-sidebar__subheader">
+      <h4>Kilder</h4>
+    </div>
+    <div class="lls-filter-sidebar__options">
+      <button
+        *ngIf="sidebarCategoryOpen['source']"
+        class="lls-filter-sidebar__option lls-sidebar__item"
+        [tabindex]="openSidebar ? 0 : -1"
+        (click)="toggleCategory('source', '')"
+      >
+      <svg class="lls-filter-sidebar__option-icon lls-icon">
+        <use [attr.href]="featherIconPath + '#arrow-left'"></use>
+      </svg>
+        Tilbage
+      </button>
+      <ng-container *ngFor="let category of filtersCategories('source') | keyvalue">
+        <ng-container *ngIf="!sidebarCategoryOpen['source']">
+          <button
+            class="lls-filter-sidebar__option lls-sidebar__item"
+            [tabindex]="openSidebar ? 0 : -1"
+            (click)="toggleCategory('source', category.key)"
+          >
+            <svg class="lls-icon lls-icon--left u-mr-2">
+              <use [attr.href]="featherIconPath + '#' + sourceIcon(category.key)"></use>
+            </svg>
+            {{ category.value.display }}
+            <span class="lls-filter-sidebar__option-count">{{'\u00A0'}} ({{ filtersCategories('source')[category.key].filters.length }})</span>
+            <svg class="lls-filter-sidebar__option-icon lls-filter-sidebar__option-item--right lls-icon">
+              <use [attr.href]="featherIconPath + '#arrow-right'"></use>
+            </svg>
+          </button>
+        </ng-container>
+        <ng-container *ngIf="sidebarCategoryOpen['source'] === category.key">
+          <button
+            *ngFor="let option of category.value.filters, index as i"
+            class="lls-filter-sidebar__option lls-sidebar__item"
+            [class]="activeFilter(option.value) ? 'lls-filter-sidebar__option--active' : ''"
+            [tabindex]="openSidebar ? 0 : -1"
+            (click)="addFilter(option)"
+          >
+            <svg class="lls-icon lls-icon--left u-mr-2">
+              <use [attr.href]="featherIconPath + '#' + (activeFilter(option.value) ? 'check-square' : 'square')"></use>
+            </svg>
+            {{ option.label }}
+            <span class="lls-filter-sidebar__option-count lls-filter-sidebar__option-item--right">
+              {{ option.count }}
+            </span>
+          </button>
+        </ng-container>
       </ng-container>
-      <ng-container *ngIf="sidebarCategoryOpen['source'] === category.key">
-        <button
-          *ngFor="let option of category.value.filters, index as i"
-          class="lls-filter-sidebar__option lls-sidebar__item"
-          [class]="activeFilter(option.value) ? 'lls-filter-sidebar__option--active' : ''"
-          [tabindex]="openSidebar ? 0 : -1"
-          (click)="addFilter(option)"
-        >
-          <svg class="lls-icon lls-icon--left u-mr-2">
-            <use [attr.href]="featherIconPath + '#' + (activeFilter(option.value) ? 'check-square' : 'square')"></use>
-          </svg>
-          {{ option.label }}
-          <span class="lls-filter-sidebar__option-count lls-filter-sidebar__option-item--right">
-            {{ option.count }}
-          </span>
-        </button>
+    </div>
+  </ng-container>
+  <ng-container *ngIf="!sidebarCategoryOpen['source']">
+    <div class="lls-sidebar__subheader">
+      <h4>Hændelser</h4>
+    </div>
+    <div class="lls-filter-sidebar__options">
+      <button
+        *ngIf="sidebarCategoryOpen['eventType']"
+        class="lls-filter-sidebar__option lls-sidebar__item"
+        [tabindex]="openSidebar ? 0 : -1"
+        (click)="toggleCategory('eventType', '')"
+      >
+      <svg class="lls-filter-sidebar__option-icon lls-icon">
+        <use [attr.href]="featherIconPath + '#arrow-left'"></use>
+      </svg>
+        Tilbage
+      </button>
+      <ng-container *ngFor="let category of filtersCategories('eventType') | keyvalue">
+        <ng-container *ngIf="!sidebarCategoryOpen['eventType']">
+          <button
+            class="lls-filter-sidebar__option lls-sidebar__item"
+            [tabindex]="openSidebar ? 0 : -1"
+            (click)="toggleCategory('eventType', category.key)"
+          >
+            <svg class="lls-icon lls-icon--left u-mr-2">
+              <use [attr.href]="featherIconPath + '#' + eventIcon(category.key)"></use>
+            </svg>
+            {{ category.value.display }}
+            <span class="lls-filter-sidebar__option-count">{{'\u00A0'}} ({{ filtersCategories('eventType')[category.key].filters.length }})</span>
+            <svg class="lls-filter-sidebar__option-icon lls-filter-sidebar__option-item--right lls-icon">
+              <use [attr.href]="featherIconPath + '#arrow-right'"></use>
+            </svg>
+          </button>
+        </ng-container>
+        <ng-container *ngIf="sidebarCategoryOpen['eventType'] === category.key">
+          <button
+            *ngFor="let option of category.value.filters, index as i"
+            class="lls-filter-sidebar__option lls-sidebar__item"
+            [class]="activeFilter(option.value) ? 'lls-filter-sidebar__option--active' : ''"
+            [tabindex]="openSidebar ? 0 : -1"
+            (click)="addFilter(option)"
+          >
+            <svg class="lls-icon lls-icon--left u-mr-2">
+              <use [attr.href]="featherIconPath + '#' + (activeFilter(option.value) ? 'check-square' : 'square')"></use>
+            </svg>
+            {{ option.label }}
+            <span class="lls-filter-sidebar__option-count lls-filter-sidebar__option-item--right">
+              {{ option.count }}
+            </span>
+          </button>
+        </ng-container>
       </ng-container>
-    </ng-container>
-  </div>
-  <div class="lls-sidebar__subheader">
-    <h4>Hændelser</h4>
-  </div>
-  <div class="lls-filter-sidebar__options">
-    <button
-      *ngIf="sidebarCategoryOpen['eventType']"
-      class="lls-filter-sidebar__option lls-sidebar__item"
-      [tabindex]="openSidebar ? 0 : -1"
-      (click)="toggleCategory('eventType', '')"
-    >
-    <svg class="lls-filter-sidebar__option-icon lls-icon">
-      <use [attr.href]="featherIconPath + '#arrow-left'"></use>
-    </svg>
-      Tilbage
-    </button>
-    <ng-container *ngFor="let category of filtersCategories('eventType') | keyvalue">
-      <ng-container *ngIf="!sidebarCategoryOpen['eventType']">
-        <button
-          class="lls-filter-sidebar__option lls-sidebar__item"
-          [tabindex]="openSidebar ? 0 : -1"
-          (click)="toggleCategory('eventType', category.key)"
-        >
-          <svg class="lls-icon lls-icon--left u-mr-2">
-            <use [attr.href]="featherIconPath + '#' + eventIcon(category.key)"></use>
-          </svg>
-          {{ category.value.display }}
-          <span class="lls-filter-sidebar__option-count">{{'\u00A0'}} ({{ filtersCategories('eventType')[category.key].filters.length }})</span>
-          <svg class="lls-filter-sidebar__option-icon lls-filter-sidebar__option-item--right lls-icon">
-            <use [attr.href]="featherIconPath + '#arrow-right'"></use>
-          </svg>
-        </button>
-      </ng-container>
-      <ng-container *ngIf="sidebarCategoryOpen['eventType'] === category.key">
-        <button
-          *ngFor="let option of category.value.filters, index as i"
-          class="lls-filter-sidebar__option lls-sidebar__item"
-          [class]="activeFilter(option.value) ? 'lls-filter-sidebar__option--active' : ''"
-          [tabindex]="openSidebar ? 0 : -1"
-          (click)="addFilter(option)"
-        >
-          <svg class="lls-icon lls-icon--left u-mr-2">
-            <use [attr.href]="featherIconPath + '#' + (activeFilter(option.value) ? 'check-square' : 'square')"></use>
-          </svg>
-          {{ option.label }}
-          <span class="lls-filter-sidebar__option-count lls-filter-sidebar__option-item--right">
-            {{ option.count }}
-          </span>
-        </button>
-      </ng-container>
-    </ng-container>
-  </div>
+    </div>
+  </ng-container>
 </aside>

--- a/src/app/filter-sidebar/view.html
+++ b/src/app/filter-sidebar/view.html
@@ -31,7 +31,7 @@
     </svg>
       Tilbage
     </button>
-    <ng-container *ngFor="let category of filtersCategories | keyvalue">
+    <ng-container *ngFor="let category of filtersCategories('eventType') | keyvalue">
       <ng-container *ngIf="!sidebarCategoryOpen">
         <button
           class="lls-filter-sidebar__option lls-sidebar__item"
@@ -42,7 +42,7 @@
             <use [attr.href]="featherIconPath + '#' + eventIcon(category.key)"></use>
           </svg>
           {{ category.value.display }}
-          <span class="lls-filter-sidebar__option-count">{{'\u00A0'}} ({{ filtersCategories[category.key].filters.length }})</span>
+          <span class="lls-filter-sidebar__option-count">{{'\u00A0'}} ({{ filtersCategories('eventType')[category.key].filters.length }})</span>
           <svg class="lls-filter-sidebar__option-icon lls-filter-sidebar__option-item--right lls-icon">
             <use [attr.href]="featherIconPath + '#arrow-right'"></use>
           </svg>

--- a/src/app/filter-sidebar/view.html
+++ b/src/app/filter-sidebar/view.html
@@ -16,110 +16,67 @@
       </svg>
     </button>
   </div>
-  <ng-container *ngIf="!sidebarCategoryOpen['eventType']">
+  <div class="lls-filter-sidebar__options">
     <div class="lls-sidebar__subheader">
-      <h4>Kilder</h4>
-    </div>
-    <div class="lls-filter-sidebar__options">
       <button
-        *ngIf="sidebarCategoryOpen['source']"
         class="lls-filter-sidebar__option lls-sidebar__item"
         [tabindex]="openSidebar ? 0 : -1"
-        (click)="toggleCategory('source', '')"
+        (click)="toggleCategory('source')"
       >
-      <svg class="lls-filter-sidebar__option-icon lls-icon">
-        <use [attr.href]="featherIconPath + '#arrow-left'"></use>
-      </svg>
-        Tilbage
+        Kilder
+        <svg class="lls-filter-sidebar__option-icon lls-icon">
+          <use [attr.href]="featherIconPath + '#arrow-right'"></use>
+        </svg>
       </button>
-      <ng-container *ngFor="let category of filtersCategories('source') | keyvalue">
-        <ng-container *ngIf="!sidebarCategoryOpen['source']">
-          <button
-            class="lls-filter-sidebar__option lls-sidebar__item"
-            [tabindex]="openSidebar ? 0 : -1"
-            (click)="toggleCategory('source', category.key)"
-          >
-            <svg class="lls-icon lls-icon--left u-mr-2">
-              <use [attr.href]="featherIconPath + '#' + sourceIcon(category.key)"></use>
-            </svg>
-            {{ category.value.display }}
-            <span class="lls-filter-sidebar__option-count">{{'\u00A0'}} ({{ filtersCategories('source')[category.key].filters.length }})</span>
-            <svg class="lls-filter-sidebar__option-icon lls-filter-sidebar__option-item--right lls-icon">
-              <use [attr.href]="featherIconPath + '#arrow-right'"></use>
-            </svg>
-          </button>
-        </ng-container>
-        <ng-container *ngIf="sidebarCategoryOpen['source'] === category.key">
-          <button
-            *ngFor="let option of category.value.filters, index as i"
-            class="lls-filter-sidebar__option lls-sidebar__item"
-            [class]="activeFilter(option.value) ? 'lls-filter-sidebar__option--active' : ''"
-            [tabindex]="openSidebar ? 0 : -1"
-            (click)="addFilter(option)"
-          >
-            <svg class="lls-icon lls-icon--left u-mr-2">
-              <use [attr.href]="featherIconPath + '#' + (activeFilter(option.value) ? 'check-square' : 'square')"></use>
-            </svg>
-            {{ option.label }}
-            <span class="lls-filter-sidebar__option-count lls-filter-sidebar__option-item--right">
-              {{ option.count }}
-            </span>
-          </button>
-        </ng-container>
-      </ng-container>
     </div>
-  </ng-container>
-  <ng-container *ngIf="!sidebarCategoryOpen['source']">
-    <div class="lls-sidebar__subheader">
-      <h4>Hændelser</h4>
-    </div>
-    <div class="lls-filter-sidebar__options">
+    <ng-container *ngIf="sidebarCategoryOpen['source']">
       <button
-        *ngIf="sidebarCategoryOpen['eventType']"
+        *ngFor="let option of filtersCategories('source'), index as i"
+        class="lls-filter-sidebar__option lls-sidebar__item"
+        [class]="activeFilter(option.value) ? 'lls-filter-sidebar__option--active' : ''"
+        [tabindex]="openSidebar ? 0 : -1"
+        (click)="addFilter(option)"
+      >
+        <svg class="lls-icon lls-icon--left u-mr-2">
+          <use [attr.href]="featherIconPath + '#' + (activeFilter(option.value) ? 'check-square' : 'square')"></use>
+        </svg>
+        {{ option.label }}
+        <span class="lls-filter-sidebar__option-count lls-filter-sidebar__option-item--right">
+          {{ option.count }}
+        </span>
+      </button>
+    </ng-container>
+  </div>
+
+  <div class="lls-filter-sidebar__options">
+    <div class="lls-sidebar__subheader">
+      <button
         class="lls-filter-sidebar__option lls-sidebar__item"
         [tabindex]="openSidebar ? 0 : -1"
-        (click)="toggleCategory('eventType', '')"
+        (click)="toggleCategory('eventType')"
       >
-      <svg class="lls-filter-sidebar__option-icon lls-icon">
-        <use [attr.href]="featherIconPath + '#arrow-left'"></use>
-      </svg>
-        Tilbage
+        Hændelser
+        <svg class="lls-filter-sidebar__option-icon lls-icon">
+          <use [attr.href]="featherIconPath + '#arrow-right'"></use>
+        </svg>
       </button>
-      <ng-container *ngFor="let category of filtersCategories('eventType') | keyvalue">
-        <ng-container *ngIf="!sidebarCategoryOpen['eventType']">
-          <button
-            class="lls-filter-sidebar__option lls-sidebar__item"
-            [tabindex]="openSidebar ? 0 : -1"
-            (click)="toggleCategory('eventType', category.key)"
-          >
-            <svg class="lls-icon lls-icon--left u-mr-2">
-              <use [attr.href]="featherIconPath + '#' + eventIcon(category.key)"></use>
-            </svg>
-            {{ category.value.display }}
-            <span class="lls-filter-sidebar__option-count">{{'\u00A0'}} ({{ filtersCategories('eventType')[category.key].filters.length }})</span>
-            <svg class="lls-filter-sidebar__option-icon lls-filter-sidebar__option-item--right lls-icon">
-              <use [attr.href]="featherIconPath + '#arrow-right'"></use>
-            </svg>
-          </button>
-        </ng-container>
-        <ng-container *ngIf="sidebarCategoryOpen['eventType'] === category.key">
-          <button
-            *ngFor="let option of category.value.filters, index as i"
-            class="lls-filter-sidebar__option lls-sidebar__item"
-            [class]="activeFilter(option.value) ? 'lls-filter-sidebar__option--active' : ''"
-            [tabindex]="openSidebar ? 0 : -1"
-            (click)="addFilter(option)"
-          >
-            <svg class="lls-icon lls-icon--left u-mr-2">
-              <use [attr.href]="featherIconPath + '#' + (activeFilter(option.value) ? 'check-square' : 'square')"></use>
-            </svg>
-            {{ option.label }}
-            <span class="lls-filter-sidebar__option-count lls-filter-sidebar__option-item--right">
-              {{ option.count }}
-            </span>
-          </button>
-        </ng-container>
-      </ng-container>
     </div>
-  </ng-container>
+    <ng-container *ngIf="sidebarCategoryOpen['eventType']">
+      <button
+        *ngFor="let option of filtersCategories('eventType'), index as i"
+        class="lls-filter-sidebar__option lls-sidebar__item"
+        [class]="activeFilter(option.value) ? 'lls-filter-sidebar__option--active' : ''"
+        [tabindex]="openSidebar ? 0 : -1"
+        (click)="addFilter(option)"
+      >
+        <svg class="lls-icon lls-icon--left u-mr-2">
+          <use [attr.href]="featherIconPath + '#' + (activeFilter(option.value) ? 'check-square' : 'square')"></use>
+        </svg>
+        {{ option.label }}
+        <span class="lls-filter-sidebar__option-count lls-filter-sidebar__option-item--right">
+          {{ option.count }}
+        </span>
+      </button>
+    </ng-container>
+  </div>
 </aside>

--- a/src/app/search-history.ts
+++ b/src/app/search-history.ts
@@ -1,5 +1,5 @@
 import isEqual from 'lodash.isequal';
-import { AdvancedSearchQuery, PersonAppearance, SourceIdentifier } from './search/search.service';
+import { AdvancedSearchQuery, PersonAppearance, FilterIdentifier } from './search/search.service';
 
 const LOCAL_STORAGE_KEY = "lls_search_history";
 
@@ -22,7 +22,7 @@ export interface SearchResultSorting {
 export interface SearchHistoryEntry {
   type: SearchHistoryEntryType,
   query?: AdvancedSearchQuery,
-  sourceFilter?: SourceIdentifier[],
+  filters?: FilterIdentifier[],
   index?: string[],
   lifecourse?: LifecourseSearchHistoryEntry,
   personAppearance?: PersonAppearance,
@@ -93,12 +93,12 @@ export function addSearchHistoryEntry(entry: SearchHistoryEntry): void {
 
   const existingHistory = getSearchHistory();
 
-  const entryData = unpick(entry, "timestamp", "pagination", "sort", "sourceFilter");
+  const entryData = unpick(entry, "timestamp", "pagination", "sort", "filters");
 
   const history = [
     entry,
     ...existingHistory.filter((existingEntry) => {
-      return !isEqual(entryData, unpick(existingEntry, "timestamp", "pagination", "sort", "sourceFilter"));
+      return !isEqual(entryData, unpick(existingEntry, "timestamp", "pagination", "sort", "filters"));
     })
   ].slice(0, 50);
 
@@ -125,11 +125,11 @@ export function getLatestSearchQuery() {
       queryParams = { ...queryParams, ...entry.sort };
     }
 
-    if(entry.sourceFilter) {
+    if(entry.filters) {
       queryParams = {
         ...queryParams,
-        sourceFilter: entry.sourceFilter
-          .map(({ event_type, event_type_display, event_year_display }) => `${event_type}_${event_type_display}_${event_year_display}`)
+        filters: entry.filters
+          .map((filter) => Object.values(filter).join('_'))
           .join(",")
       };
     }

--- a/src/app/search-history/component.ts
+++ b/src/app/search-history/component.ts
@@ -47,7 +47,7 @@ export class SearchHistoryComponent implements OnInit {
       queryParams = {
         ...queryParams,
         sourceFilter: entry.sourceFilter
-          .map(({ filter_type, event_type, event_type_display, event_year_display }) => `${filter_type}_${event_type}_${event_type_display}_${event_year_display}`)
+          .map((filter) => Object.values(filter).join('_'))
           .join(",")
       };
     }

--- a/src/app/search-history/component.ts
+++ b/src/app/search-history/component.ts
@@ -47,7 +47,7 @@ export class SearchHistoryComponent implements OnInit {
       queryParams = {
         ...queryParams,
         sourceFilter: entry.sourceFilter
-          .map(({ event_type, event_type_display, event_year_display }) => `${event_type}_${event_type_display}_${event_year_display}`)
+          .map(({ filter_type, event_type, event_type_display, event_year_display }) => `${filter_type}_${event_type}_${event_type_display}_${event_year_display}`)
           .join(",")
       };
     }

--- a/src/app/search-result-list/search-result-list.component.html
+++ b/src/app/search-result-list/search-result-list.component.html
@@ -150,7 +150,7 @@
                 [(ngModel)]="sourceFilter"
                 [openSidebar]="openSidebar"
                 [featherIconPath]="config.featherIconPath"
-                [possibleSources]="possibleSources"
+                [possibleFilters]="possibleFilters"
                 (closeSidebar)="closeSidebar()"
                 (removeFilter)="removeFilter($event)"
             ></lls-filter-sidebar>

--- a/src/app/search-result-list/search-result-list.component.ts
+++ b/src/app/search-result-list/search-result-list.component.ts
@@ -101,7 +101,7 @@ export class SearchResultListComponent implements OnInit {
   }
 
   get possibleFilters() {
-    const possibleFilters = this.searchResult.meta.possibleFilters.sort((a, b) => {
+    const sortedEventTypeFilter = (filter) => (filter.sort((a, b) => {
       if(a.event_year_display < b.event_year_display) {
         return -1;
       }
@@ -109,8 +109,23 @@ export class SearchResultListComponent implements OnInit {
         return 1;
       }
       return 0;
-    });
-    return {'eventType': possibleFilters};
+    }));
+
+    const sortedSourceFilter = (filter) => (filter.sort((a, b) => {
+      if(a.source_year_display < b.source_year_display) {
+        return -1;
+      }
+      if(a.source_year_display > b.source_year_display) {
+        return 1;
+      }
+      return 0;
+    }));
+
+    const { eventType, source } = this.searchResult.meta.possibleFilters;
+    return {
+      eventType: sortedEventTypeFilter(eventType),
+      source: sortedSourceFilter(source),
+    }
   }
 
   get resultRangeDescription() {

--- a/src/app/search-result-list/search-result-list.component.ts
+++ b/src/app/search-result-list/search-result-list.component.ts
@@ -100,8 +100,8 @@ export class SearchResultListComponent implements OnInit {
     };
   }
 
-  get possibleSources() {
-    const possibleSources = this.searchResult.meta.possibleSources.sort((a, b) => {
+  get possibleFilters() {
+    const possibleFilters = this.searchResult.meta.possibleFilters.sort((a, b) => {
       if(a.event_year_display < b.event_year_display) {
         return -1;
       }
@@ -110,7 +110,7 @@ export class SearchResultListComponent implements OnInit {
       }
       return 0;
     });
-    return {'eventType': possibleSources};
+    return {'eventType': possibleFilters};
   }
 
   get resultRangeDescription() {

--- a/src/app/search-result-list/search-result-list.component.ts
+++ b/src/app/search-result-list/search-result-list.component.ts
@@ -102,20 +102,20 @@ export class SearchResultListComponent implements OnInit {
 
   get possibleFilters() {
     const sortedEventTypeFilter = (filter) => (filter.sort((a, b) => {
-      if(a.event_year_display < b.event_year_display) {
+      if(a.event_type_display.toLowerCase() < b.event_type_display.toLowerCase()) {
         return -1;
       }
-      if(a.event_year_display > b.event_year_display) {
+      if(a.event_type_display.toLowerCase() > b.event_type_display.toLowerCase()) {
         return 1;
       }
       return 0;
     }));
 
     const sortedSourceFilter = (filter) => (filter.sort((a, b) => {
-      if(a.source_year_display < b.source_year_display) {
+      if(a.source_type_display.toLowerCase() < b.source_type_display.toLowerCase()) {
         return -1;
       }
-      if(a.source_year_display > b.source_year_display) {
+      if(a.source_type_display.toLowerCase() > b.source_type_display.toLowerCase()) {
         return 1;
       }
       return 0;
@@ -255,7 +255,7 @@ export class SearchResultListComponent implements OnInit {
   }
 
   getIconFromSourceFilterValue(filterValue: string) {
-    const [_,event_type, __, ___] = filterValue.split("_");
+    const [_,event_type, __] = filterValue.split("_");
     return eventIcon(event_type);
   }
 
@@ -265,7 +265,7 @@ export class SearchResultListComponent implements OnInit {
   }
 
   getEventTypeFromSourceFilterValue(filterValue: string) {
-    const [_,__, event_type_display, ___] = filterValue.split("_");
+    const [_,__, event_type_display] = filterValue.split("_");
     return event_type_display;
   }
 

--- a/src/app/search-result-list/search-result-list.component.ts
+++ b/src/app/search-result-list/search-result-list.component.ts
@@ -101,7 +101,7 @@ export class SearchResultListComponent implements OnInit {
   }
 
   get possibleSources() {
-    return this.searchResult.meta.possibleSources.sort((a, b) => {
+    const possibleSources = this.searchResult.meta.possibleSources.sort((a, b) => {
       if(a.event_year_display < b.event_year_display) {
         return -1;
       }
@@ -110,6 +110,7 @@ export class SearchResultListComponent implements OnInit {
       }
       return 0;
     });
+    return {'eventType': possibleSources};
   }
 
   get resultRangeDescription() {
@@ -239,17 +240,17 @@ export class SearchResultListComponent implements OnInit {
   }
 
   getIconFromSourceFilterValue(filterValue: string) {
-    const [event_type, _, __] = filterValue.split("_");
+    const [_,event_type, __, ___] = filterValue.split("_");
     return eventIcon(event_type);
   }
 
   getYearFromSourceFilterValue(filterValue: string) {
-    const [_, __, event_year_display] = filterValue.split("_");
+    const [_,__, ___, event_year_display] = filterValue.split("_");
     return event_year_display;
   }
 
   getEventTypeFromSourceFilterValue(filterValue: string) {
-    const [_, event_type_display, __] = filterValue.split("_");
+    const [_,__, event_type_display, ___] = filterValue.split("_");
     return event_type_display;
   }
 

--- a/src/app/search-result-list/search-result-resolver.service.ts
+++ b/src/app/search-result-list/search-result-resolver.service.ts
@@ -38,21 +38,19 @@ export class SearchResultResolverService implements Resolve<SearchResult> {
         .map((id) => {
           const filter_type = id.split("_")[0];
           if(filter_type == 'eventType') {
-            const [ filter_type, event_type, event_type_display, event_year_display ] = id.split("_");
+            const [ filter_type, event_type, event_type_display ] = id.split("_");
             return {
               filter_type,
               event_type,
               event_type_display,
-              event_year_display,
             };
           }
           if(filter_type == 'source') {
-            const [ filter_type, source_type_wp4, source_type_display, source_year_display ] = id.split("_");
+            const [ filter_type, source_type_wp4, source_type_display ] = id.split("_");
             return {
               filter_type,
               source_type_wp4,
               source_type_display,
-              source_year_display,
             };
           }
         });

--- a/src/app/search-result-list/search-result-resolver.service.ts
+++ b/src/app/search-result-list/search-result-resolver.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { AdvancedSearchQuery, SearchResult, SearchService, SourceIdentifier } from '../search/search.service';
+import { AdvancedSearchQuery, SearchResult, SearchService, FilterIdentifier } from '../search/search.service';
 import { Resolve, ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
 import { Observable, EMPTY } from 'rxjs';
 import { addSearchHistoryEntry, SearchHistoryEntryType } from '../search-history';
@@ -30,14 +30,15 @@ export class SearchResultResolverService implements Resolve<SearchResult> {
     let sortOrder: "asc" | "desc" = route.queryParamMap.get('sortOrder') === "desc" ? "desc" : "asc";
     const sourceFilterRaw = route.queryParamMap.get("sourceFilter");
 
-    let sourceFilter: SourceIdentifier[] = [];
+    let sourceFilter: FilterIdentifier[] = [];
     if(sourceFilterRaw) {
       sourceFilter = sourceFilterRaw
         .split(",")
         .filter(x => x)
         .map((id) => {
-          const [ event_type, event_type_display, event_year_display ] = id.split("_");
+          const [ filter_type, event_type, event_type_display, event_year_display ] = id.split("_");
           return {
+            filter_type,
             event_type,
             event_type_display,
             event_year_display,
@@ -78,7 +79,7 @@ export class SearchResultResolverService implements Resolve<SearchResult> {
     addSearchHistoryEntry({
       type: SearchHistoryEntryType.SearchResult,
       query: actualSearchTerms,
-      sourceFilter,
+      filters: sourceFilter,
       index,
       pagination: { page, size },
       sort: { sortBy, sortOrder },

--- a/src/app/search-result-list/search-result-resolver.service.ts
+++ b/src/app/search-result-list/search-result-resolver.service.ts
@@ -36,13 +36,25 @@ export class SearchResultResolverService implements Resolve<SearchResult> {
         .split(",")
         .filter(x => x)
         .map((id) => {
-          const [ filter_type, event_type, event_type_display, event_year_display ] = id.split("_");
-          return {
-            filter_type,
-            event_type,
-            event_type_display,
-            event_year_display,
-          };
+          const filter_type = id.split("_")[0];
+          if(filter_type == 'eventType') {
+            const [ filter_type, event_type, event_type_display, event_year_display ] = id.split("_");
+            return {
+              filter_type,
+              event_type,
+              event_type_display,
+              event_year_display,
+            };
+          }
+          if(filter_type == 'source') {
+            const [ filter_type, source_type_wp4, source_type_display, source_year_display ] = id.split("_");
+            return {
+              filter_type,
+              source_type_wp4,
+              source_type_display,
+              source_year_display,
+            };
+          }
         });
     }
 

--- a/src/app/search/search.service.ts
+++ b/src/app/search/search.service.ts
@@ -34,8 +34,8 @@ export interface SearchResult {
   hits: SearchHit[],
   meta: {
     possibleFilters: {
-      eventType: Array<{ event_year_display: string, event_type: string, event_type_display: string, count: number }>,
-      source: Array<{ source_year_display: string, source_type_wp4: string, source_type_display: string, count: number }>
+      eventType: Array<{ event_type: string, event_type_display: string, count: number }>,
+      source: Array<{ source_type_wp4: string, source_type_display: string, count: number }>
     },
   }
 }
@@ -142,14 +142,12 @@ export interface EventTypeFilterIdentifier {
   filter_type: string,
   event_type: string,
   event_type_display: string,
-  event_year_display: string,
 };
 
 export interface SourceFilterIdentifier {
   filter_type: string,
   source_type_wp4: string,
   source_type_display: string,
-  source_year_display: string,
 };
 
 export type FilterIdentifier = EventTypeFilterIdentifier | SourceFilterIdentifier;

--- a/src/app/search/search.service.ts
+++ b/src/app/search/search.service.ts
@@ -135,13 +135,21 @@ export interface Source {
   link: string,
   institution: string,
 };
-
-export interface SourceIdentifier {
+export interface EventTypeFilterIdentifier {
+  filter_type: string,
   event_type: string,
   event_type_display: string,
   event_year_display: string,
 };
 
+export interface SourceFilterIdentifier {
+  filter_type: string,
+  source_type_wp4: string,
+  source_type_display: string,
+  source_year_display: string,
+};
+
+export type FilterIdentifier = EventTypeFilterIdentifier | SourceFilterIdentifier;
 export interface AdvancedSearchQuery {
   query?: string,
   name?: string,
@@ -165,7 +173,7 @@ export class SearchService {
 
   constructor(private elasticsearch: ElasticsearchService) { }
 
-  advancedSearch(query: AdvancedSearchQuery, indices: string[], from: number, size: number, sortBy: string, sortOrder: string, sourceFilter: SourceIdentifier[], mode: string = "default"): Observable<SearchResult> {
+  advancedSearch(query: AdvancedSearchQuery, indices: string[], from: number, size: number, sortBy: string, sortOrder: string, sourceFilter: FilterIdentifier[], mode: string = "default"): Observable<SearchResult> {
     return this.elasticsearch.searchAdvanced(query, indices, from, size, sortBy, sortOrder, sourceFilter, mode);
   }
 }

--- a/src/app/search/search.service.ts
+++ b/src/app/search/search.service.ts
@@ -33,7 +33,10 @@ export interface SearchResult {
   },
   hits: SearchHit[],
   meta: {
-    possibleFilters: Array<{ event_year_display: string, event_type: string, event_type_display: string, count: number }>,
+    possibleFilters: {
+      eventType: Array<{ event_year_display: string, event_type: string, event_type_display: string, count: number }>,
+      source: Array<{ source_year_display: string, source_type_wp4: string, source_type_display: string, count: number }>
+    },
   }
 }
 

--- a/src/app/search/search.service.ts
+++ b/src/app/search/search.service.ts
@@ -33,7 +33,7 @@ export interface SearchResult {
   },
   hits: SearchHit[],
   meta: {
-    possibleSources: Array<{ event_year_display: string, event_type: string, event_type_display: string, count: number }>,
+    possibleFilters: Array<{ event_year_display: string, event_type: string, event_type_display: string, count: number }>,
   }
 }
 


### PR DESCRIPTION
Now we can both filter on sources and on events.

When choosing multiple filteroptions from same filter type, it should act like 'or clauses' (broadening the search) 
When choosing filteroptions across filter types, it should act like 'and clauses' (narrowing the search)

The implementation is very naive, and styling and refactoring should be done in next PR.