### PR TITLE
adds interceptors that fetchs a auth0 token and adds a auth bearer to…

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -3,6 +3,9 @@ import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule }   from '@angular/forms';
 // Import the module from the SDK
 import { AuthModule } from '@auth0/auth0-angular';
+// Import the injector module and the HTTP client module from Angular
+import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
+import { AuthHttpInterceptor } from '@auth0/auth0-angular';
 
 import { SearchModule } from './search/search.module';
 import { AppRoutingModule } from './app-routing.module';
@@ -39,7 +42,6 @@ import { UserProfilePage } from './user-profile/user-profile.component';
     LifeCourseItemComponent,
     SearchHistoryComponent,
     LinkRatingComponent,
-//    AuthButtonComponent,
     UserProfileComponent,
     FilterSidebar,
     UserProfilePage,
@@ -51,13 +53,48 @@ import { UserProfilePage } from './user-profile/user-profile.component';
     FormsModule,
     ReactiveFormsModule,
     FormElementsModule,
+    HttpClientModule,
     // Import the module into the application, with configuration
     AuthModule.forRoot({
       domain: 'linklives.eu.auth0.com',
-      clientId: '7lYbAwzUER3epciKfadgIoO8LUmhIk5x'
+      clientId: '7lYbAwzUER3epciKfadgIoO8LUmhIk5x',
+      // Request this audience at user authentication time
+      audience: 'https://api.linklives.dk',
+
+      // Specify configuration for the interceptor
+      httpInterceptor: {
+        allowedList: [
+          {
+            // Match requests to the auth0 manager API
+            uri: 'https://linklives.eu.auth0.com/api/v2/*',
+            tokenOptions: {
+              // The attached token should target this audience (auht0 API ID)
+              audience: 'https://linklives.eu.auth0.com/api/v2/',
+            }
+          },
+          {
+            // Match requests to the custom API (test)
+            uri: 'https://api-test.link-lives.dk/*',
+            tokenOptions: {
+              // The attached token should target this audience (auht0 API ID)
+              audience: 'https://api.linklives.dk',
+            }
+          },
+          {
+            // Match requests to the custom API (production)
+            uri: 'https://api.link-lives.dk/*',
+            tokenOptions: {
+              // The attached token should target this audience (auht0 API ID)
+              audience: 'https://api.linklives.dk',
+            }
+          }
+        ]
+      }
     }),
   ],
-  providers: [],
+  providers: [
+    { provide: HTTP_INTERCEPTORS, useClass: AuthHttpInterceptor, multi: true },
+  ],
   bootstrap: [AppComponent]
 })
 export class AppModule { }


### PR DESCRIPTION
toggle: Authorization  

________________________

Adds interceptors that fetch an auth0 token and adds an auth bearer token to requests when we call the LinkLive API and the auth0 management API (latter might not be nessecary).

We might want to update the intercepter to match only relevant endpoints (ratings endpoints and lifecourses based on user id).

![image](https://user-images.githubusercontent.com/6737691/128685751-171e0d35-6c9c-4d13-8382-e89b2f07644a.png)