### PR TITLE
Link rating data through api

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -3,6 +3,9 @@ import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule }   from '@angular/forms';
 // Import the module from the SDK
 import { AuthModule } from '@auth0/auth0-angular';
+// Import the injector module and the HTTP client module from Angular
+import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
+import { AuthHttpInterceptor } from '@auth0/auth0-angular';
 
 import { SearchModule } from './search/search.module';
 import { AppRoutingModule } from './app-routing.module';
@@ -39,7 +42,6 @@ import { UserProfilePage } from './user-profile/user-profile.component';
     LifeCourseItemComponent,
     SearchHistoryComponent,
     LinkRatingComponent,
-//    AuthButtonComponent,
     UserProfileComponent,
     FilterSidebar,
     UserProfilePage,
@@ -51,13 +53,48 @@ import { UserProfilePage } from './user-profile/user-profile.component';
     FormsModule,
     ReactiveFormsModule,
     FormElementsModule,
+    HttpClientModule,
     // Import the module into the application, with configuration
     AuthModule.forRoot({
       domain: 'linklives.eu.auth0.com',
-      clientId: '7lYbAwzUER3epciKfadgIoO8LUmhIk5x'
+      clientId: '7lYbAwzUER3epciKfadgIoO8LUmhIk5x',
+      // Request this audience at user authentication time
+      audience: 'https://api.linklives.dk',
+
+      // Specify configuration for the interceptor
+      httpInterceptor: {
+        allowedList: [
+          {
+            // Match requests to the auth0 manager API
+            uri: 'https://linklives.eu.auth0.com/api/v2/*',
+            tokenOptions: {
+              // The attached token should target this audience (auht0 API ID)
+              audience: 'https://linklives.eu.auth0.com/api/v2/',
+            }
+          },
+          {
+            // Match requests to the custom API (test)
+            uri: 'https://api-test.link-lives.dk/*',
+            tokenOptions: {
+              // The attached token should target this audience (auht0 API ID)
+              audience: 'https://api.linklives.dk',
+            }
+          },
+          {
+            // Match requests to the custom API (production)
+            uri: 'https://api.link-lives.dk/*',
+            tokenOptions: {
+              // The attached token should target this audience (auht0 API ID)
+              audience: 'https://api.linklives.dk',
+            }
+          }
+        ]
+      }
     }),
   ],
-  providers: [],
+  providers: [
+    { provide: HTTP_INTERCEPTORS, useClass: AuthHttpInterceptor, multi: true },
+  ],
   bootstrap: [AppComponent]
 })
 export class AppModule { }

--- a/src/app/elasticsearch/elasticsearch.service.ts
+++ b/src/app/elasticsearch/elasticsearch.service.ts
@@ -172,6 +172,7 @@ export interface Link {
   method_type: string,
   method_subtype1: string,
   score: number,
+  key: string,
 }
 
 export interface LinksSearchResult {
@@ -879,6 +880,7 @@ export class ElasticsearchService {
                 method_type: link.method_type,
                 method_subtype1: link.method_subtype1,
                 score: link.score,
+                key: link.key,
               }));
 
             observer.next(links);
@@ -938,4 +940,11 @@ export class ElasticsearchService {
     )
   }
 
+  sendLinkRating(linkRating: any): Observable<any> {
+    return this.http.post<any>(`${environment.apiUrl}/LinkRating`, linkRating);
+  }
+
+  getLinkRatingStats(key: string): Observable<any> {
+    return this.http.get<any>(`${environment.apiUrl}/Link/${key}/ratings/stats`);
+  }
 };

--- a/src/app/elasticsearch/elasticsearch.service.ts
+++ b/src/app/elasticsearch/elasticsearch.service.ts
@@ -895,7 +895,7 @@ export class ElasticsearchService {
     return result;
   }
 
-  getLinkRatingOptions(): Observable<LinkRatingOptions> {   
+  getLinkRatingOptions(): Observable<LinkRatingOptions> {
     return new Observable<LinkRatingOptions>(    
       observer => {
         this.http.get<LinkRatingOptionsResult>(`${environment.apiUrl}/ratingOptions`)

--- a/src/app/life-course/life-course.component.html
+++ b/src/app/life-course/life-course.component.html
@@ -51,9 +51,12 @@
         (close)="openSearchHistory = false"
     ></app-search-history>
     <app-link-rating
-        [openLinkRating]="openLinkRating"
+        [openLinkRating]="currentLinkKey"
+        [linkKey]="currentLinkKey"
+        [totalRatings]="totalRatings"
+        [ratingCountByCategory]="ratingCountByCategory"
         [featherIconPath]="featherSpriteUrl"
-        (close)="openLinkRating = false"
+        (close)="currentLinkKey = ''"
     ></app-link-rating>
     <div class="lls-life-course-source-container">
         <section class="lls-life-course-source-container__source-list lls-row">
@@ -154,7 +157,7 @@
                             {{ link.linkingMethod.short }}
                         </text>
                         <foreignObject x="0" y="100" width="80%" height="100%" style="text-align: center;">
-                            <xhtml:button class="lls-btn lls-btn--small lls-btn--blue" (click)="openLinkRating = true">
+                            <xhtml:button class="lls-btn lls-btn--small lls-btn--blue" (click)="openLinkRating(link.key)">
                                 Er linket troværdigt?
                             </button>
                             <xhtml:div class="u-mt-2">

--- a/src/app/life-course/life-course.component.ts
+++ b/src/app/life-course/life-course.component.ts
@@ -4,6 +4,7 @@ import { Link } from '../elasticsearch/elasticsearch.service';
 import { prettyDate } from '../display-helpers';
 import { PersonAppearance } from '../search/search.service';
 import { getLatestSearchQuery } from '../search-history';
+import { ElasticsearchService } from '../elasticsearch/elasticsearch.service';
 
 @Component({
   selector: 'app-life-course',
@@ -22,7 +23,9 @@ export class LifeCourseComponent implements OnInit {
 
   featherSpriteUrl = this.config.featherIconPath;
   openSearchHistory: boolean = false;
-  openLinkRating: boolean = false;
+  currentLinkKey: string = "";
+  totalRatings;
+  ratingCountByCategory;
 
   get pasReversed() {
     return [ ...this.pas ].reverse();
@@ -108,6 +111,7 @@ export class LifeCourseComponent implements OnInit {
         pathTierX: tier * 16 + 10,
         confidencePct: Math.round((1 - link.score) * 100),
         linkingMethod: prettyLinkMethod(link),
+        key: link.key,
       };
     });
   }
@@ -156,7 +160,15 @@ export class LifeCourseComponent implements OnInit {
     return prettyDate(date);
   }
 
-  constructor(private route: ActivatedRoute) { }
+  openLinkRating(linkKey) {
+    this.currentLinkKey = linkKey;
+    this.elasticsearch.getLinkRatingStats(linkKey).subscribe(linkRatingData => {
+      this.totalRatings = linkRatingData.totalRatings
+      this.ratingCountByCategory = linkRatingData.headingRatings;
+    });
+  }
+
+  constructor(private route: ActivatedRoute, private elasticsearch: ElasticsearchService) { }
 
   ngOnInit(): void {
     this.route.data.subscribe(next => {

--- a/src/app/link-rating/component.html
+++ b/src/app/link-rating/component.html
@@ -69,7 +69,7 @@
       </button>
     </div>
     <p>
-      Her er hvad du og de {{ totalRatings }} brugere har svaret.
+      Her er hvad du og de {{ totalRatings - 1 }} brugere har svaret.
     </p>
       <div *ngFor="let ratingCount of ratingCountByCategory | keyvalue">
         <div class="u-flex u-space-between u-align-items u-mt-4">

--- a/src/app/link-rating/component.html
+++ b/src/app/link-rating/component.html
@@ -22,11 +22,11 @@
       </button>
     </div>
     <form [formGroup]="linkRatingForm" (ngSubmit)="onSubmit()">
-      <div *ngFor="let optionCategory of linkOptions" class="u-mt-4">
+      <div *ngFor="let optionGroup of ratingOptions" class="u-mt-4">
         <h4>
-          {{ optionCategory.category }}
+          {{ optionGroup.category }}
         </h4>
-        <div *ngFor="let option of optionCategory.options">
+        <div *ngFor="let option of optionGroup.options">
           <label class="u-text-small u-flex u-align-items u-direction-row">
             <input type="radio"
               [value]="option.value"
@@ -40,7 +40,7 @@
       </div>
       <div class="u-flex u-align-items u-mt-4">
         <button class="lls-btn lls-btn--small lls-btn--blue u-mr-2" type="submit">Giv feedback</button>
-        <p class="u-text-small u-margin-0">{{ numberOfRatings }} brugere har givet feedback</p>
+        <p class="u-text-small u-margin-0">{{ totalRatings }} brugere har givet feedback</p>
       </div>
     </form>
     <span class="u-mt-4">
@@ -69,9 +69,9 @@
       </button>
     </div>
     <p>
-      Her er hvad du og de {{ numberOfRatings }} brugere har svaret.
+      Her er hvad du og de {{ totalRatings }} brugere har svaret.
     </p>
-      <div *ngFor="let optionCategory of linkOptions">
+      <div *ngFor="let optionCategory of ratingOptions">
         <div class="u-flex u-space-between u-align-items u-mt-4">
           <h4 class='u-margin-0'>
             {{ optionCategory.category }}
@@ -83,7 +83,7 @@
             {{ percent(optionCategory.category) }}%
           </p>
         </div>
-        <progress class="lls-progress" id="file" [max]="numberOfRatings" [value]="numberOfAnswers[optionCategory.category]"></progress>
+        <progress class="lls-progress" id="file" [max]="totalRatings" [value]="numberOfAnswers[optionCategory.category]"></progress>
       </div>
     <span>
       Hvordan bruger vi din feedback og hvordan bedømmes dine links?

--- a/src/app/link-rating/component.html
+++ b/src/app/link-rating/component.html
@@ -71,19 +71,19 @@
     <p>
       Her er hvad du og de {{ totalRatings }} brugere har svaret.
     </p>
-      <div *ngFor="let optionCategory of ratingOptions">
+      <div *ngFor="let ratingCount of ratingCountByCategory | keyvalue">
         <div class="u-flex u-space-between u-align-items u-mt-4">
           <h4 class='u-margin-0'>
-            {{ optionCategory.category }}
+            {{ ratingCount.key }}
           </h4>
-          <p *ngIf="chosen == optionCategory.category" class="u-text-grey--light u-text-very-small u-margin-0">
+          <p *ngIf="chosen == ratingCount.key" class="u-text-grey--light u-text-very-small u-margin-0">
             Du har stemt her
           </p>
           <p class='u-margin-0'>
-            {{ percent(optionCategory.category) }}%
+            {{ percent(ratingCount.value) }}%
           </p>
         </div>
-        <progress class="lls-progress" id="file" [max]="totalRatings" [value]="numberOfAnswers[optionCategory.category]"></progress>
+        <progress class="lls-progress" id="file" [max]="totalRatings" [value]="ratingCount.value"></progress>
       </div>
     <span>
       Hvordan bruger vi din feedback og hvordan bedømmes dine links?

--- a/src/app/link-rating/component.ts
+++ b/src/app/link-rating/component.ts
@@ -14,17 +14,17 @@ import { ElasticsearchService } from '../elasticsearch/elasticsearch.service';
 export class LinkRatingComponent implements OnInit {
   @Input() openLinkRating: boolean;
   @Input() featherIconPath: string;
+  @Input() linkKey: string;
+  @Input() totalRatings: number;
+  @Input() ratingCountByCategory: any;
   @Output() close: EventEmitter<any> = new EventEmitter();
 
   showForm = true;
+  chosen: string = "";
   ratingOptions;
-  totalRatings = 11;
-  chosen: string;
-  numberOfAnswers;
 
-  percent(category) {
-    const currentNumberOfAnswers = this.numberOfAnswers[category];
-    return Math.round(parseInt(currentNumberOfAnswers) / this.totalRatings * 100);
+  percent(ratingCount) {
+    return Math.round(parseInt(ratingCount) / this.totalRatings * 100);
   }
 
   linkRatingForm = new FormGroup({
@@ -32,28 +32,35 @@ export class LinkRatingComponent implements OnInit {
   });
 
   onSubmit() {
-    const chosenOption = this.linkRatingForm.value.option;
-    // update api
-    const ratingOption = this.ratingOptions.find(optionCategory => optionCategory.options.some(option => option.value == chosenOption));
-    this.chosen = ratingOption.category;
+    const chosenRatingId = this.linkRatingForm.value.option;
+    const ratingData = {
+      ratingId: chosenRatingId,
+      linkKey: this.linkKey,
+    }
+
+    const linkOption = this.ratingOptions.find(optionCategory => optionCategory.options.some(option => option.value == chosenRatingId));
+    this.chosen = linkOption.category;
+
+    this.elasticsearch.sendLinkRating(ratingData).subscribe(rate => {
+      // update rating stats
+      this.totalRatings++;
+      this.ratingCountByCategory[linkOption.category]++;
+    });
+
+    this.elasticsearch.getLinkRatingStats(this.linkKey).subscribe(linkRatingData => {
+      this.totalRatings = linkRatingData.totalRatings
+      this.ratingCountByCategory = linkRatingData.headingRatings;
+    });
+
     this.showForm = false;
   }
 
   closeLinkRating() {
     this.showForm = true;
-    this.ratingOptions = this.ratingOptions.map(option => ({...option, chosen: false}));
+    this.chosen = "";
+    this.openLinkRating = false;
+    this.linkRatingForm.reset();
     this.close.emit(null);
-  }
-
-  fillNumerOfAnswers() {
-    // something like this should be done after fetching link rating data
-    let i = 2;
-    this.numberOfAnswers = {};
-    for (const optionCategory of this.ratingOptions as any) {
-      const category = optionCategory.category;
-      i += 2;
-      this.numberOfAnswers[category] = i;
-    }
   }
 
   ngOnInit(): void {
@@ -67,10 +74,8 @@ export class LinkRatingComponent implements OnInit {
   }
 
   constructor(private elasticsearch: ElasticsearchService) {
-    this.elasticsearch.getLinkRatingOptions().subscribe(
-      ratingOptions => {  
+    this.elasticsearch.getLinkRatingOptions().subscribe(ratingOptions => {
       this.ratingOptions = ratingOptions;
-      this.fillNumerOfAnswers();
-      });
+    });  
   }  
 }

--- a/src/app/link-rating/component.ts
+++ b/src/app/link-rating/component.ts
@@ -17,14 +17,14 @@ export class LinkRatingComponent implements OnInit {
   @Output() close: EventEmitter<any> = new EventEmitter();
 
   showForm = true;
-  linkOptions;
-  numberOfRatings = 11;
+  ratingOptions;
+  totalRatings = 11;
   chosen: string;
   numberOfAnswers;
 
   percent(category) {
     const currentNumberOfAnswers = this.numberOfAnswers[category];
-    return Math.round(parseInt(currentNumberOfAnswers) / this.numberOfRatings * 100);
+    return Math.round(parseInt(currentNumberOfAnswers) / this.totalRatings * 100);
   }
 
   linkRatingForm = new FormGroup({
@@ -34,14 +34,14 @@ export class LinkRatingComponent implements OnInit {
   onSubmit() {
     const chosenOption = this.linkRatingForm.value.option;
     // update api
-    const linkOption = this.linkOptions.find(optionCategory => optionCategory.options.some(option => option.value == chosenOption));
-    this.chosen = linkOption.category;
+    const ratingOption = this.ratingOptions.find(optionCategory => optionCategory.options.some(option => option.value == chosenOption));
+    this.chosen = ratingOption.category;
     this.showForm = false;
   }
 
   closeLinkRating() {
     this.showForm = true;
-    this.linkOptions = this.linkOptions.map(option => ({...option, chosen: false}));
+    this.ratingOptions = this.ratingOptions.map(option => ({...option, chosen: false}));
     this.close.emit(null);
   }
 
@@ -49,7 +49,7 @@ export class LinkRatingComponent implements OnInit {
     // something like this should be done after fetching link rating data
     let i = 2;
     this.numberOfAnswers = {};
-    for (const optionCategory of this.linkOptions as any) {
+    for (const optionCategory of this.ratingOptions as any) {
       const category = optionCategory.category;
       i += 2;
       this.numberOfAnswers[category] = i;
@@ -68,8 +68,8 @@ export class LinkRatingComponent implements OnInit {
 
   constructor(private elasticsearch: ElasticsearchService) {
     this.elasticsearch.getLinkRatingOptions().subscribe(
-      linkOptions => {  
-      this.linkOptions = linkOptions;
+      ratingOptions => {  
+      this.ratingOptions = ratingOptions;
       this.fillNumerOfAnswers();
       });
   }  


### PR DESCRIPTION

Changes:  
- get link rating stats from API. We get the data right when we open the modal to make it possible to name how many ratings have been made on a certain link.
- send link ratings to the API. Notice that the totalRatings count will add up each time you rate the link 