### PR TITLE
get personAppearance endpoint return elastic search _search result 

### DIFF
--- a/src/app/elasticsearch/elasticsearch.service.ts
+++ b/src/app/elasticsearch/elasticsearch.service.ts
@@ -830,9 +830,9 @@ export class ElasticsearchService {
   getPersonAppearance(id: string|number): Observable<PersonAppearance> {
     return new Observable(
       observer => {
-        this.http.get<ElasticDocResult>(`${environment.apiUrl}/PersonAppearance/${id}`)
+        this.http.get<ElasticSearchResult>(`${environment.apiUrl}/PersonAppearance/${id}`)
         .subscribe(next => {
-            observer.next(next._source.person_appearance as PersonAppearance);
+            observer.next(next.hits.hits[0]._source.person_appearance as PersonAppearance);
           }, error => {
             observer.error(error);
           }, () => {

--- a/src/app/elasticsearch/elasticsearch.service.ts
+++ b/src/app/elasticsearch/elasticsearch.service.ts
@@ -832,7 +832,11 @@ export class ElasticsearchService {
       observer => {
         this.http.get<ElasticSearchResult>(`${environment.apiUrl}/PersonAppearance/${id}`)
         .subscribe(next => {
-            observer.next(next.hits.hits[0]._source.person_appearance as PersonAppearance);
+            try {
+              observer.next(next.hits.hits[0]._source.person_appearance as PersonAppearance);
+            } catch (error) {
+              observer.error(error);
+            }
           }, error => {
             observer.error(error);
           }, () => {


### PR DESCRIPTION
the API uses elastic search *_search* endpoint instead of *_doc* endpoint when getting the personAppearance. Therefore the response is an elasticSearchResult.

The response of this endpoint will change in next week to include the source data and to remove the elastic search meta-data