### PR TITLE
Get lifecourses by key through api

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -36,7 +36,7 @@ const routes: Routes = [
     },
   },
   {
-    path: 'life-course/:id',
+    path: 'life-course/:key',
     component: LifeCourseComponent,
     resolve: {
       lifecourse: LifeCourseResolverService

--- a/src/app/elasticsearch/elasticsearch.service.ts
+++ b/src/app/elasticsearch/elasticsearch.service.ts
@@ -527,7 +527,12 @@ export class ElasticsearchService {
 
       const searchKeyConfig = mapSearchKeys[queryKey];
 
-      if(!searchKeyConfig && queryKey != "lifeCourseId") {
+      // special case handled at the end of this method
+      if(queryKey == "lifeCourseId") {
+        return;
+      }
+
+      if(!searchKeyConfig) {
         return console.warn("[elasticsearch.service] key we don't know how to search on provided", queryKey);
       }
 

--- a/src/app/elasticsearch/elasticsearch.service.ts
+++ b/src/app/elasticsearch/elasticsearch.service.ts
@@ -16,6 +16,7 @@ export interface ElasticDocResult {
   found: boolean,
   _source: {
     life_course_id?: number,
+    life_course_key?: string,
     source?: Source,
     person_appearance?: PersonAppearance | PersonAppearance[]
   }
@@ -27,6 +28,7 @@ export interface ElasticSearchHit {
   _id: number,
   _score: number,
   _source: {
+    key: string,
     life_course_ids?: number[],
     person_appearance: PersonAppearance | PersonAppearance[]
   }
@@ -221,6 +223,7 @@ export class ElasticsearchService {
       return {
         type: "lifecourses",
         life_course_id: elasticHit._id,
+        life_course_key: elasticHit._source.key,
         pas: elasticHit._source.person_appearance as PersonAppearance[]
       };
     }
@@ -799,13 +802,12 @@ export class ElasticsearchService {
     };
   }
 
-  getLifecourse(id: string|number): Observable<Lifecourse> {
+  getLifecourse(key: string): Observable<Lifecourse> {
     return new Observable(
       observer => {
-        // this.http.get<ElasticDocResult>(`${environment.apiUrl}/lifecourse/${id}`)
-        this.http.get<ElasticDocResult>(`https://data-dev.link-lives.dk/lifecourses/_doc/${id}`)
+         this.http.get<Lifecourse>(`${environment.apiUrl}/lifecourse/${key}`)
         .subscribe(next => {
-            observer.next(next._source as Lifecourse);
+            observer.next(next as Lifecourse);
           }, error => {
             observer.error(error);
           }, () => {

--- a/src/app/life-course/life-course-item.component.html
+++ b/src/app/life-course/life-course-item.component.html
@@ -41,7 +41,7 @@
 
     <div class="lls-source__section lls-source__section--cta">
         <div>
-            <a href [routerLink]="['/life-course', lifecourseId]" class="lls-btn lls-btn--blue lls-btn--link">
+            <a href [routerLink]="['/life-course', lifecourseKey]" class="lls-btn lls-btn--blue lls-btn--link">
                 <span>Se forløb</span>
                 <svg class="lls-icon lls-icon--right">
                     <use [attr.href]="featherSpriteUrl + '#arrow-right'"></use>

--- a/src/app/life-course/life-course-item.component.ts
+++ b/src/app/life-course/life-course-item.component.ts
@@ -9,7 +9,7 @@ import { PersonAppearance } from '../search/search.service';
 export class LifeCourseItemComponent implements OnInit {
 
   @Input('item') personAppearances: PersonAppearance[];
-  @Input('lifecourse-id') lifecourseId: number;
+  @Input('lifecourse-key') lifecourseKey: string;
 
   get config() {
     return window["lls"];

--- a/src/app/life-course/life-course-resolver.service.ts
+++ b/src/app/life-course/life-course-resolver.service.ts
@@ -9,38 +9,40 @@ import { addSearchHistoryEntry, SearchHistoryEntryType } from '../search-history
 @Injectable({
   providedIn: 'root'
 })
-export class LifeCourseResolverService implements Resolve<{lifecourseId:number, personAppearances: PersonAppearance[]}> {
+export class LifeCourseResolverService implements Resolve<{lifecourseKey: string, personAppearances: PersonAppearance[]}> {
 
   constructor(private elasticsearch: ElasticsearchService) { }
 
-  resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<{ lifecourseId: number; personAppearances: PersonAppearance[]; links: Link[]; }> {
-    const lifecourseId = route.params['id'];
+  resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<{ lifecourseKey: string; personAppearances: PersonAppearance[]; links: Link[]; }> {
+    const lifecourseKey = route.params['key'];
 
-    return this.elasticsearch.getLifecourse(lifecourseId)
-      .pipe(mergeMap((lifecourse: Lifecourse, index) => {
-        addSearchHistoryEntry({
-          type: SearchHistoryEntryType.Lifecourse,
-          lifecourse: {
-            id: lifecourseId,
-            personAppearances: lifecourse.person_appearance,
-          },
-        });
-
-        return this.elasticsearch.searchLinks(lifecourse.person_appearance)
-          .pipe(map((linksResult, index) => {
-            const paIds: string[] = lifecourse.person_appearance.map((pa) => `${pa.source_id}-${pa.pa_id}`);
-            const links = linksResult.filter((link) => {
-              const linkStartId = `${link.source_id1}-${link.pa_id1}`;
-              const linkEndId = `${link.source_id2}-${link.pa_id2}`;
-              return paIds.includes(linkStartId) && paIds.includes(linkEndId);
+    return new Observable(
+      observer => {
+        this.elasticsearch.getLifecourse(lifecourseKey)
+          .pipe(map((lifecourse: Lifecourse, index) => {
+            addSearchHistoryEntry({
+              type: SearchHistoryEntryType.Lifecourse,
+              lifecourse: {
+                key: lifecourseKey,
+                personAppearances: lifecourse.personAppearances || [],
+              },
             });
-
             return {
-              lifecourseId,
-              personAppearances: lifecourse.person_appearance,
-              links,
+              lifecourseKey,
+              personAppearances: lifecourse.personAppearances,
+              links: lifecourse.links,
             };
-          }));
-      }));
+          }
+          ))
+          .subscribe(next => {
+            observer.next(next);
+          }, error => {
+            observer.error(error);
+          }, () => {
+            observer.complete();
+          }
+        )
+      }
+    );
   }
 }

--- a/src/app/life-course/life-course.component.html
+++ b/src/app/life-course/life-course.component.html
@@ -177,7 +177,7 @@
                 <div class="lls-data-page-footer__entry-label">
                     Forløbs ID
                 </div>
-                <a [href]="'life-course/' + lifecourseId">{{ lifecourseId }}</a>
+                <a [href]="'life-course/' + lifecourseKey">{{ lifecourseKey }}</a>
             </div>
             <div class="lls-data-page-footer__entry">
                 <div class="lls-data-page-footer__entry-label">

--- a/src/app/life-course/life-course.component.ts
+++ b/src/app/life-course/life-course.component.ts
@@ -43,7 +43,7 @@ export class LifeCourseComponent implements OnInit {
       return [
         `${link.source_id1}-${link.pa_id1}`,
         `${link.source_id2}-${link.pa_id2}`
-      ].includes(`${pa.id}`);
+      ].includes(pa.id);
     };
 
     const getIndexLength = (link: Link) => {

--- a/src/app/life-course/life-course.component.ts
+++ b/src/app/life-course/life-course.component.ts
@@ -13,7 +13,7 @@ import { ElasticsearchService } from '../elasticsearch/elasticsearch.service';
 export class LifeCourseComponent implements OnInit {
 
   pas: PersonAppearance[] = [];
-  lifecourseId: number;
+  lifecourseKey: string;
   links: Link[];
   getLatestSearchQuery = getLatestSearchQuery;
 
@@ -173,7 +173,7 @@ export class LifeCourseComponent implements OnInit {
   ngOnInit(): void {
     this.route.data.subscribe(next => {
       this.pas = next.lifecourse.personAppearances as PersonAppearance[];
-      this.lifecourseId = next.lifecourse.lifecourseId;
+      this.lifecourseKey = next.lifecourse.lifecourseKey;
       this.links = next.lifecourse.links;
     });
   }

--- a/src/app/life-course/life-course.component.ts
+++ b/src/app/life-course/life-course.component.ts
@@ -43,7 +43,7 @@ export class LifeCourseComponent implements OnInit {
       return [
         `${link.source_id1}-${link.pa_id1}`,
         `${link.source_id2}-${link.pa_id2}`
-      ].includes(`${pa.source_id}-${pa.pa_id}`);
+      ].includes(`${pa.id}`);
     };
 
     const getIndexLength = (link: Link) => {

--- a/src/app/person-appearance/person-appearance.component.html
+++ b/src/app/person-appearance/person-appearance.component.html
@@ -4,7 +4,7 @@
             <a
                 *ngIf="previousSearchHistoryEntryIsConnectedLifecourse()"
                 class="lls-data-page-header__utility-link"
-                [routerLink]="['/life-course', previousSearchHistoryEntry.lifecourse.id]"
+                [routerLink]="['/life-course', previousSearchHistoryEntry.lifecourse.key]"
             >
                 Tilbage til livsforløb
             </a>

--- a/src/app/search-history.ts
+++ b/src/app/search-history.ts
@@ -33,7 +33,7 @@ export interface SearchHistoryEntry {
 }
 
 export interface LifecourseSearchHistoryEntry {
-  id: string,
+  key: string,
   personAppearances: PersonAppearance[],
 }
 

--- a/src/app/search-history/component.html
+++ b/src/app/search-history/component.html
@@ -47,7 +47,7 @@
             *ngSwitchCase="'lifecourse'"
             class="lls-sidebar__item lls-sidebar__item--link lls-search-history__item lls-search-history__item-link"
             [tabIndex]="openSearchHistory ? 0 : -1"
-            [routerLink]="['/life-course', entry.lifecourse.id]"
+            [routerLink]="['/life-course', entry.lifecourse.key]"
             (click)="closeSearchHistory()"
         >
             <div>

--- a/src/app/search-result-list/search-result-list.component.html
+++ b/src/app/search-result-list/search-result-list.component.html
@@ -232,7 +232,7 @@
     <div class="lls-row">
         <ng-container *ngFor="let hit of searchResult.hits" [ngSwitch]="hit.type">
             <app-person-appearance-item *ngSwitchCase="'pas'" class="lls-columns-12" [item]="hit.pa"></app-person-appearance-item>
-            <app-life-course-item *ngSwitchCase="'lifecourses'" class="lls-columns-12" [item]="hit.pas" [lifecourse-id]="hit.life_course_id"></app-life-course-item>
+            <app-life-course-item *ngSwitchCase="'lifecourses'" class="lls-columns-12" [item]="hit.pas" [lifecourse-key]="hit.life_course_key"></app-life-course-item>
         </ng-container>
         <div *ngIf="!searchResult.hits.length" class="lls-columns-12 u-text-center">
             <p>

--- a/src/app/search/search.service.ts
+++ b/src/app/search/search.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Observable, of } from 'rxjs';
 
-import { ElasticsearchService } from '../elasticsearch/elasticsearch.service';
+import { ElasticsearchService, Link } from '../elasticsearch/elasticsearch.service';
 
 export type SearchHit = PersonAppearanceHit | LinkHit | LifecourseHit;
 
@@ -20,6 +20,7 @@ export interface LinkHit {
 export interface LifecourseHit {
   type: "lifecourses",
   life_course_id: number,
+  life_course_key: string,
   pas: PersonAppearance[]
 }
 
@@ -129,8 +130,10 @@ export interface PersonAppearance {
 }
 
 export interface Lifecourse {
+  key: string, // actual identifier
   life_course_id: number,
-  person_appearance: PersonAppearance[]
+  personAppearances: PersonAppearance[]
+  links: Link[]
 }
 
 export interface Source {


### PR DESCRIPTION
**Toggl**: Man kan ikke klikke på personregistrering og se oplysninger fra kilden om personen - API endpoint get /LifeCourse/{key} opdatering af data  
**Trello**: [Man kan ikke klikke på personregistrering og se oplysninger fra kilden om personen - API endpoint get /LifeCourse/{key} opdatering af](https://trello.com/c/BQw7xIrw/181-man-kan-ikke-klikke-p%C3%A5-personregistrering-og-se-oplysninger-fra-kilden-om-personen-api-endpoint-get-lifecourse-key-opdatering-af)

## Changes:

- Use lifecourse key as identifier for lifecourses instead of the id.  
- Get lifecourses using the API instead of directly from elastic search.  
- Get lifecouse endpoint is including the links in the lifecourse, therefore we dont need to get theese after getting the lifecourse
-  