### PR TITLE
Show rated lifecourses

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -88,10 +88,17 @@ import { UserProfilePage } from './user-profile/user-profile.component';
               audience: 'https://api.linklives.dk',
             }
           },
-
           {
             // Match requests to the custom API (production)
             uri: 'https://api.link-lives.dk/LinkRating',
+            tokenOptions: {
+              // The attached token should target this audience (auht0 API ID)
+              audience: 'https://api.linklives.dk',
+            }
+          },
+          {
+            // Match requests to the custom API (test)
+            uri: 'https://api.link-lives.dk/user/ratings/lifecourses',
             tokenOptions: {
               // The attached token should target this audience (auht0 API ID)
               audience: 'https://api.linklives.dk',

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -81,6 +81,15 @@ import { UserProfilePage } from './user-profile/user-profile.component';
             }
           },
           {
+            // Match requests to the custom API (test)
+            uri: 'https://api-test.link-lives.dk/user/ratings/lifecourses',
+            tokenOptions: {
+              // The attached token should target this audience (auht0 API ID)
+              audience: 'https://api.linklives.dk',
+            }
+          },
+
+          {
             // Match requests to the custom API (production)
             uri: 'https://api.link-lives.dk/LinkRating',
             tokenOptions: {

--- a/src/app/elasticsearch/elasticsearch.service.ts
+++ b/src/app/elasticsearch/elasticsearch.service.ts
@@ -908,6 +908,10 @@ export class ElasticsearchService {
     return result;
   }
 
+  getRatedLifecourses(): Observable<any> {
+    return this.http.get<any>(`${environment.apiUrl}/user/ratings/lifecourses`);
+  }
+
   getLinkRatingOptions(): Observable<LinkRatingOptions> {
     return new Observable<LinkRatingOptions>(    
       observer => {

--- a/src/app/user-profile/user-profile.component.html
+++ b/src/app/user-profile/user-profile.component.html
@@ -66,4 +66,24 @@
       </button>
     </div>
   </div>
+
+  <!-- Livsforløb -->
+
+  <div class="lls-sidebar__header" style="margin-bottom: 0px;">
+    <h3>Livsforløb</h3>
+  </div>
+  <p>
+    Livsforløb du har bedømt
+  </p>
+
+  <div>
+    <ng-container *ngFor="let lifecourse of ratedLifecourses">
+        <app-life-course-item class="lls-columns-12" [item]="lifecourse.personAppearances" [lifecourse-key]="lifecourse.key"></app-life-course-item>
+    </ng-container>
+    <div *ngIf="!ratedLifecourses.length" class="lls-columns-12 u-text-center">
+        <p>
+            Du har ikke bedømt nogle links.
+        </p>
+    </div>
+  </div>
 </div>

--- a/src/app/user-profile/user-profile.component.html
+++ b/src/app/user-profile/user-profile.component.html
@@ -14,7 +14,7 @@
         </ng-template>
       </h1>
       <p class="lls-data-page-header__data-summary">
-        <span>Du har bedømt X links og tilføjet X nye links</span>
+        <span>Du har bedømt links for {{ ratedLifecourses.length }} livsforløb</span>
       </p>
     </div>
     <div>

--- a/src/app/user-profile/user-profile.component.ts
+++ b/src/app/user-profile/user-profile.component.ts
@@ -1,5 +1,6 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { AuthService } from '@auth0/auth0-angular';
+import { ElasticsearchService } from '../elasticsearch/elasticsearch.service';
 
 
 @Component({
@@ -7,9 +8,11 @@ import { AuthService } from '@auth0/auth0-angular';
   templateUrl: './user-profile.component.html'
 })
 
-export class UserProfilePage {
-  constructor(public auth: AuthService) {}
+export class UserProfilePage implements OnInit {
+  constructor(public auth: AuthService, private elasticsearch: ElasticsearchService) {}
+
   isEditingProfile:boolean = true;
+  ratedLifecourses: any;
 
   get config() {
     return window["lls"];
@@ -24,4 +27,11 @@ export class UserProfilePage {
   };
 
   featherSpriteUrl = this.config.featherIconPath;
+  
+  ngOnInit(): void {
+    this.elasticsearch.getRatedLifecourses().subscribe((ratedLifecourses) => {
+      console.log('ratedLifecourses within', ratedLifecourses);
+      this.ratedLifecourses = ratedLifecourses;
+    });  
+  }
 }

--- a/src/app/user-profile/user-profile.component.ts
+++ b/src/app/user-profile/user-profile.component.ts
@@ -32,6 +32,6 @@ export class UserProfilePage implements OnInit {
     this.elasticsearch.getRatedLifecourses().subscribe((ratedLifecourses) => {
       console.log('ratedLifecourses within', ratedLifecourses);
       this.ratedLifecourses = ratedLifecourses;
-    });  
+    });
   }
 }


### PR DESCRIPTION
**toggle**: Vis livsforløb en bruger har ratet  
**trello**: [Som bruger vil jeg gerne kune se en oversigt over hvilke livsforløb jeg har ratet link på](https://trello.com/c/9wrg6f5U/196-som-bruger-vil-jeg-gerne-kune-se-en-oversigt-over-hvilke-livsforl%C3%B8b-jeg-har-ratet-link-p%C3%A5)

### Additions:

- endpoint to get lifecourses with links that have been rated
- on user profile page the list of lifecourses is shown in the same manner as search results

### Changes:

- http interceptor added for this endpoint to ensure authorization
