### PR TITLE
Visual fix on results-type checkboxes on search result page.

### DIFF
--- a/src/app/search/simple/search-simple.component.html
+++ b/src/app/search/simple/search-simple.component.html
@@ -174,7 +174,7 @@
             </svg>
           </button>
 
-          <label class="lls-search-options__checkbox-container mx-4">
+          <label class="lls-search-options__checkbox-container my-4">
             <input
               [(ngModel)]="modeFuzzy"
               type="checkbox"

--- a/src/app/search/simple/search-simple.component.html
+++ b/src/app/search/simple/search-simple.component.html
@@ -163,7 +163,7 @@
           </div>
         </div>
 
-        <div class="u-mt-2">
+        <div class="u-flex u-mt-2">
           <button
             type="submit"
             class="lls-btn lls-btn--big"
@@ -174,7 +174,7 @@
             </svg>
           </button>
 
-          <label class="lls-search-options__checkbox-container my-4">
+          <label class="lls-search-options__checkbox-container ml-4">
             <input
               [(ngModel)]="modeFuzzy"
               type="checkbox"

--- a/src/assets/styling/results-header.scss
+++ b/src/assets/styling/results-header.scss
@@ -51,14 +51,16 @@
 
 .lls-results-header__checkboxes {
   display: flex;
-  height: 45px;
-  align-items: center;
+  flex-direction: column;
 }
 
 .lls-results-header__checkbox-container {
-  margin-right: 10px;
+  margin-bottom: 0.5rem;
   font-size: 1rem;
-  margin-bottom: 0;
+
+  @media(min-width: $breakpointMd) {
+    margin-bottom: 0;
+  }
 }
 
 .lls-results-header__checkbox {

--- a/src/assets/styling/search-options.scss
+++ b/src/assets/styling/search-options.scss
@@ -15,6 +15,12 @@
 
 .lls-search-options__checkbox-container {
   margin-right: 1rem;
+  display: flex;
+  align-items: center;
+
+  @media(max-width: $breakpointSm) {
+    font-size: 0.85rem;
+  }
 }
 
 .lls-search-options__checkbox {


### PR DESCRIPTION
Since the text changed from "kilde" to "personregistrering" our UI has been shown to be unable to deal with longer strings. 

**Fix:** They are now beneath each other to avoid problems if the label text gets too long.
Not the most elegant solution, but a more robust one.

## After fix (mobile):
![image](https://user-images.githubusercontent.com/8166831/129873063-ee9d5dc6-7527-42a4-92af-4a1394a63983.png)
## After fix (desktop):
![image](https://user-images.githubusercontent.com/8166831/129873124-d2ce47a2-f976-479d-bd45-ea81a77b434d.png)

## Before fix:
![image](https://user-images.githubusercontent.com/8166831/129873266-211a9026-66a9-4223-b0c9-f33aac605922.png)

