### PR TITLE
Fix Search result items' CTA labels on tablet

### DIFF
--- a/src/assets/styling/life-course-page.scss
+++ b/src/assets/styling/life-course-page.scss
@@ -27,7 +27,6 @@
   width: 200px;
   height: 100%;
   display: none;
-  margin-left: 1rem;
   margin-top: 3.625rem;
 
   @media(min-width: $breakpointMd) {

--- a/src/assets/styling/source-card.scss
+++ b/src/assets/styling/source-card.scss
@@ -118,6 +118,14 @@
 
   @media(min-width: $breakpointMd) {
     justify-content: flex-end;
+    padding-left: 0;
+  }
+
+  // Quickfix: Make sure that the CTA button text does not have linebreaks on tablet
+  .lls-btn {
+    @media(min-width: $breakpointMd) and (max-width: $breakpointLg) {
+      font-size: 0.9rem;
+    }
   }
 }
 


### PR DESCRIPTION
### Problem:
Button text breaking into two lines because of too much text.
![image](https://user-images.githubusercontent.com/8166831/129884270-8bc04eaf-4dcd-4967-87e8-54d69dfa701f.png)


### Fix:
Decrease padding and button text size on tablet. Other devices should not be affected by these changes.
![image](https://user-images.githubusercontent.com/8166831/129884291-55a09968-8214-4fa8-ad24-1188f11d7810.png)
