### PR TITLE
filter should only show number of person appearances.

### DIFF
--- a/src/app/elasticsearch/elasticsearch.service.ts
+++ b/src/app/elasticsearch/elasticsearch.service.ts
@@ -310,27 +310,27 @@ export class ElasticsearchService {
       search: this.http.post<ElasticSearchResult>(`${environment.apiUrl}/search/${indices.join(',')}`, body).pipe(share()),
     };
     if(eventFilterBody) {
-      requests.eventLookup = this.http.post<ElasticEventLookupResult>(`${environment.apiUrl}/search/${indices.join(',')}`, eventFilterBody).pipe(share());
+      requests.eventLookup = this.http.post<ElasticEventLookupResult>(`${environment.apiUrl}/search/pas`, eventFilterBody).pipe(share());
     }
 
     if(sourceFilterBody) {
-      requests.sourceLookup = this.http.post<ElasticSourceLookupResult>(`${environment.apiUrl}/search/${indices.join(',')}`, sourceFilterBody).pipe(share());
+      requests.sourceLookup = this.http.post<ElasticSourceLookupResult>(`${environment.apiUrl}/search/pas`, sourceFilterBody).pipe(share());
     }
 
     if(eventYearFilterBody) {
-      requests.eventYearLookup = this.http.post<ElasticEventYearLookupResult>(`${environment.apiUrl}/search/${indices.join(',')}`, eventYearFilterBody).pipe(share());
+      requests.eventYearLookup = this.http.post<ElasticEventYearLookupResult>(`${environment.apiUrl}/search/pas`, eventYearFilterBody).pipe(share());
     }
 
     if(sourceYearFilterBody) {
-      requests.sourceYearLookup = this.http.post<ElasticSourceYearLookupResult>(`${environment.apiUrl}/search/${indices.join(',')}`, sourceYearFilterBody).pipe(share());
+      requests.sourceYearLookup = this.http.post<ElasticSourceYearLookupResult>(`${environment.apiUrl}/search/pas`, sourceYearFilterBody).pipe(share());
     }
 
     if(birthYearFilterBody) {
-      requests.birthYearLookup = this.http.post<ElasticBirthYearLookupResult>(`${environment.apiUrl}/search/${indices.join(',')}`, birthYearFilterBody).pipe(share());
+      requests.birthYearLookup = this.http.post<ElasticBirthYearLookupResult>(`${environment.apiUrl}/search/pas`, birthYearFilterBody).pipe(share());
     }
 
     if(deathYearFilterBody) {
-      requests.deathYearLookup = this.http.post<ElasticDeathYearLookupResult>(`${environment.apiUrl}/search/${indices.join(',')}`, deathYearFilterBody).pipe(share());
+      requests.deathYearLookup = this.http.post<ElasticDeathYearLookupResult>(`${environment.apiUrl}/search/pas`, deathYearFilterBody).pipe(share());
     }
 
     // Prep observable that will send both requests and merge results in handleResult


### PR DESCRIPTION
**Før:**
Der er 11 søgeresultater = 4 livsforløb + 7 personregisteringer

I Filtret er der blevet talt:
4 livsforløb med 2 kilder hver = 8 personregisteringer.
7 personregisteringer + 8 personregisteringer fra livsforløb
= 15 resultater.

Forslået løsning:
Jeg opdatere filtret til kun at tælle personregisteringer