### PR TITLE
Show amount of pas and lifecourses instead of total hits

### DIFF
--- a/src/app/elasticsearch/elasticsearch.service.ts
+++ b/src/app/elasticsearch/elasticsearch.service.ts
@@ -280,10 +280,10 @@ export class ElasticsearchService {
 
     searchResult.aggregations?.count.buckets.forEach(value => {
       result.totalHits += value.doc_count;
-      if (value.key == "pas") {
+      if (value.key.includes("pas")) {
         result.indexHits.pas = value.doc_count;
       }
-      if (value.key == "lifecourses") {
+      if (value.key.includes("lifecourses")) {
         result.indexHits.lifeCourses = value.doc_count;
       }
     });

--- a/src/app/search-result-list/search-result-list.component.ts
+++ b/src/app/search-result-list/search-result-list.component.ts
@@ -133,7 +133,6 @@ export class SearchResultListComponent implements OnInit {
     const prettyTotal = this.prettyPaginationNumber(this.searchResult.totalHits);
     const totalLifecourses = this.prettyPaginationNumber(this.searchResult.indexHits.lifeCourses);
     const totalPas = this.prettyPaginationNumber(this.searchResult.indexHits.pas);
-    console.log("lifeCourses", this.searchResult);
 
     if(this.searchResult.totalHits < this.pagination.size) {
       return `Viser ${totalLifecourses} livsforløb og ${totalPas} personregistreringer`;

--- a/src/app/search-result-list/search-result-list.component.ts
+++ b/src/app/search-result-list/search-result-list.component.ts
@@ -131,9 +131,12 @@ export class SearchResultListComponent implements OnInit {
 
   get resultRangeDescription() {
     const prettyTotal = this.prettyPaginationNumber(this.searchResult.totalHits);
+    const totalLifecourses = this.prettyPaginationNumber(this.searchResult.indexHits.lifeCourses);
+    const totalPas = this.prettyPaginationNumber(this.searchResult.indexHits.pas);
+    console.log("lifeCourses", this.searchResult);
 
     if(this.searchResult.totalHits < this.pagination.size) {
-      return `Viser alle ${prettyTotal} resultater`;
+      return `Viser ${totalLifecourses} livsforløb og ${totalPas} personregistreringer`;
     }
 
     const firstResult = ((this.pagination.current - 1) * this.pagination.size) + 1;
@@ -142,10 +145,13 @@ export class SearchResultListComponent implements OnInit {
     const prettyFirst = this.prettyPaginationNumber(firstResult);
     const prettyLast = this.prettyPaginationNumber(lastResult);
 
-    return `Viser ${prettyFirst}&ndash;${prettyLast} af ${prettyTotal} resultater`;
+    return `Viser ${prettyFirst}&ndash;${prettyLast} af ${totalLifecourses} livsforløb og ${totalPas} personregistreringer`;
   }
 
   prettyPaginationNumber(num: number) {
+    if(!num) {
+      return 0;
+    }
     return num.toLocaleString("da-DK");
   }
 


### PR DESCRIPTION
Trello: https://trello.com/c/e0tbqobQ/169-s%C3%B8geresultat-antal-opdeles-p%C3%A5-livsforl%C3%B8b-og-personregistreringer

Also avoid everything blowing up, if a number is falsy :)

![image](https://user-images.githubusercontent.com/8166831/129925075-47343b3c-780c-477a-be97-5899711f58c6.png)
