### PR TITLE
Pagination edge case fix

### DIFF
--- a/src/app/search-history/component.ts
+++ b/src/app/search-history/component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
-import { getSearchHistory, onSearchHistoryEntry, SearchHistoryEntry } from '../search-history';
+import { getSearchHistory, onSearchHistoryEntry, SearchHistoryEntry, SearchHistoryEntryType } from '../search-history';
 import { searchFieldLabels } from '../search-term-values';
 import { eventType, prettyYearRange, eventIcon } from '../util/display-helpers';
 import { PersonAppearance } from '../search/search.service';
@@ -18,7 +18,19 @@ export class SearchHistoryComponent implements OnInit {
   @Input() openSearchHistory: boolean;
   @Input() featherIconPath: string;
   @Output() close: EventEmitter<any> = new EventEmitter();
-  searchHistory: SearchHistoryEntry[] = getSearchHistory();
+
+  searchHistory: SearchHistoryEntry[] = getSearchHistory()
+    .map((entry) => {
+      if(entry.type != SearchHistoryEntryType.SearchResult) {
+        return entry;
+      }
+
+      if(Object.keys(entry.query).length == 0) {
+        entry.query.query = "";
+      }
+      return entry;
+    });
+
   searchFieldLabels = searchFieldLabels;
   prettyYearRange = prettyYearRange;
   eventIcon = eventIcon;
@@ -64,7 +76,19 @@ export class SearchHistoryComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    onSearchHistoryEntry((history) => this.searchHistory = history);
+    onSearchHistoryEntry((history) => {
+      this.searchHistory = history
+        .map((entry) => {
+          if(entry.type != SearchHistoryEntryType.SearchResult) {
+            return entry;
+          }
+
+          if(Object.keys(entry.query).length == 0) {
+            entry.query.query = "";
+          }
+          return entry;
+        });
+    });
   }
 
   closeSearchHistory() {

--- a/src/app/search-result-list/search-result-list.component.ts
+++ b/src/app/search-result-list/search-result-list.component.ts
@@ -37,6 +37,13 @@ export class SearchResultListComponent implements OnInit {
     last: number,
     size: number,
     navigationPages: number[],
+  } = {
+    current: 1,
+    firstInOrder: 1,
+    lastInOrder: 1,
+    last: 1,
+    size: 1,
+    navigationPages: [1],
   };
 
   sizeOptions = [

--- a/src/app/search-result-list/search-result-list.component.ts
+++ b/src/app/search-result-list/search-result-list.component.ts
@@ -137,7 +137,6 @@ export class SearchResultListComponent implements OnInit {
   }
 
   get resultRangeDescription() {
-    const prettyTotal = this.prettyPaginationNumber(this.searchResult.totalHits);
     const totalLifecourses = this.prettyPaginationNumber(this.searchResult.indexHits.lifeCourses);
     const totalPas = this.prettyPaginationNumber(this.searchResult.indexHits.pas);
 


### PR DESCRIPTION
When searching for literally nothing (e.g. all search fields empty) the search history would end up with an entry with no query - and when trying to go back to this entry, chaos would ensue. Searching without a single search parameter results in errors, and no search fields rendered. Instead, we now force an empty "Fritekst" field for entries with no other query fields.

Trello: Nogle gange fejler 'tilbage til søgeresultat' på livsforløb