### PR TITLE
When getting latest search query, ensure at least one search param

### DIFF
--- a/src/app/search-history.ts
+++ b/src/app/search-history.ts
@@ -131,6 +131,10 @@ export function getLatestSearchQuery() {
   if(entry) {
     let queryParams: any = { ...entry.query };
 
+    if(Object.keys(queryParams).length == 0) {
+      queryParams.query = "";
+    }
+
     if(entry.pagination) {
       const { page: pg, size } = entry.pagination;
       queryParams = { ...queryParams, pg, size };


### PR DESCRIPTION
(for the edge case where people search for empty string)