### PR TITLE
Result count text: only show counts for result types we search for

### DIFF
--- a/src/app/search-result-list/search-result-list.component.ts
+++ b/src/app/search-result-list/search-result-list.component.ts
@@ -78,8 +78,8 @@ export class SearchResultListComponent implements OnInit {
   featherSpriteUrl = this.config.featherIconPath;
 
   indices = {
-    pas: { value: false, label: "Personregistrering" },
-    lifecourses: { value: false, label: "Livsforløb" },
+    pas: { value: false, label: "Personregistrering", searchedValue: false },
+    lifecourses: { value: false, label: "Livsforløb", searchedValue: false },
   };
 
   get indexKeys() {
@@ -140,8 +140,16 @@ export class SearchResultListComponent implements OnInit {
     const totalLifecourses = this.prettyPaginationNumber(this.searchResult.indexHits.lifeCourses);
     const totalPas = this.prettyPaginationNumber(this.searchResult.indexHits.pas);
 
+    let countText = `${totalLifecourses} livsforløb og ${totalPas} personregistreringer`;
+    if(!this.indices.lifecourses.searchedValue) {
+      countText = `${totalPas} personregistreringer`;
+    }
+    if(!this.indices.pas.searchedValue) {
+      countText = `${totalLifecourses} livsforløb`;
+    }
+
     if(this.searchResult.totalHits < this.pagination.size) {
-      return `Viser ${totalLifecourses} livsforløb og ${totalPas} personregistreringer`;
+      return `Viser ${countText}`;
     }
 
     const firstResult = ((this.pagination.current - 1) * this.pagination.size) + 1;
@@ -150,7 +158,7 @@ export class SearchResultListComponent implements OnInit {
     const prettyFirst = this.prettyPaginationNumber(firstResult);
     const prettyLast = this.prettyPaginationNumber(lastResult);
 
-    return `Viser ${prettyFirst}&ndash;${prettyLast} af ${totalLifecourses} livsforløb og ${totalPas} personregistreringer`;
+    return `Viser ${prettyFirst}&ndash;${prettyLast} af ${countText}`;
   }
 
   prettyPaginationNumber(num: number) {
@@ -197,8 +205,14 @@ export class SearchResultListComponent implements OnInit {
       const indices = queryParamMap.get('index');
       if(indices) {
         // Reset index checkbox values
-        Object.keys(this.indices).forEach(index => this.indices[index].value = false);
-        indices.split(",").forEach((index) => this.indices[index].value = true);
+        Object.keys(this.indices).forEach(index => {
+          this.indices[index].value = false;
+          this.indices[index].searchedValue = false;
+        });
+        indices.split(",").forEach((index) => {
+          this.indices[index].value = true;
+          this.indices[index].searchedValue = true;
+        });
       }
       this.sortBy = queryParamMap.get('sortBy') || "relevance";
       const sortOrder = queryParamMap.get('sortOrder');

--- a/src/app/search-result-list/search-result-list.component.ts
+++ b/src/app/search-result-list/search-result-list.component.ts
@@ -283,7 +283,7 @@ export class SearchResultListComponent implements OnInit {
   getIconFromSourceFilterValue(filterValue: string) {
     const filter_type = filterValue.split("_")[0];
     if(filter_type == 'eventType') {
-      const [_,event_type, __] = filterValue.split("_");
+      const [_, event_type, __] = filterValue.split("_");
       return eventIcon(event_type);
     }
   }

--- a/src/app/search-result-list/search-result-list.component.ts
+++ b/src/app/search-result-list/search-result-list.component.ts
@@ -140,9 +140,10 @@ export class SearchResultListComponent implements OnInit {
     const totalLifecourses = this.prettyPaginationNumber(this.searchResult.indexHits.lifeCourses);
     const totalPas = this.prettyPaginationNumber(this.searchResult.indexHits.pas);
 
-    let countText = `${totalLifecourses} livsforløb og ${totalPas} personregistreringer`;
+    const pasText = `${totalPas} personregistrering${totalPas === "1" ? "" : "er"}`;
+    let countText = `${totalLifecourses} livsforløb og ${pasText}`;
     if(!this.indices.lifecourses.searchedValue) {
-      countText = `${totalPas} personregistreringer`;
+      countText = pasText;
     }
     if(!this.indices.pas.searchedValue) {
       countText = `${totalLifecourses} livsforløb`;

--- a/src/assets/styling/results-header.scss
+++ b/src/assets/styling/results-header.scss
@@ -52,6 +52,7 @@
 .lls-results-header__checkboxes {
   display: flex;
   flex-direction: column;
+  margin-bottom: 0.5rem;
 }
 
 .lls-results-header__checkbox-container {


### PR DESCRIPTION
When searching for only lifecourses only show lifecourse counts, not pa counts; and vice versa.