### PR TITLE
Fix alignment of sizes of sorting dropdowns with size of "Alle filtre" button

### DIFF
--- a/src/assets/styling/dropdown.scss
+++ b/src/assets/styling/dropdown.scss
@@ -53,6 +53,7 @@ lls-dropdown {
   justify-content: space-between;
   align-items: center;
   width: 100%;
+  line-height: 1;
 }
 
 .lls-dropdown__option-list {


### PR DESCRIPTION
The line height had been changed to 1.5 per default, which resulted in dropdowns becoming larger, because of sizing of current item in the dropdown. Fixing this to 1 realigns the sizes of the dropdowns and button. Especially visible as the height of the sort order button and sort field dropdown were misaligned

Before:
![image](https://user-images.githubusercontent.com/859106/131022871-87fe465e-f88c-4be3-a856-186ed4daf547.png)

After:
![image](https://user-images.githubusercontent.com/859106/131022919-84994e62-7415-4eb6-816b-c9439c183c33.png)
