### PR TITLE
Ensure desctructive sort is only called once

### DIFF
--- a/src/app/life-course/life-course-item.component.ts
+++ b/src/app/life-course/life-course-item.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input } from '@angular/core';
+import { Component, Input, OnChanges } from '@angular/core';
 import { prettyYearRange } from '../util/display-helpers';
 import { PersonAppearance } from '../search/search.service';
 
@@ -6,10 +6,12 @@ import { PersonAppearance } from '../search/search.service';
   selector: 'app-life-course-item',
   templateUrl: './life-course-item.component.html',
 })
-export class LifeCourseItemComponent implements OnInit {
+export class LifeCourseItemComponent implements OnChanges {
 
-  @Input('item') personAppearances: PersonAppearance[];
+  @Input('item') _pas: PersonAppearance[];
   @Input('lifecourse-key') lifecourseKey: string;
+
+  personAppearances: PersonAppearance[] = [];
 
   get config() {
     return window["lls"];
@@ -17,22 +19,8 @@ export class LifeCourseItemComponent implements OnInit {
 
   featherSpriteUrl = this.config.featherIconPath;
 
-
-  get personAppearancesSortedByYear() {
-    const sortedByYear = this.personAppearances.sort(function(a, b) {
-      if (a.event_year_display > b.event_year_display) {
-        return 1;
-      }
-      if (a.event_year_display < b.event_year_display) {
-        return -1;
-      }
-      return 0;
-    });
-    return sortedByYear;
-  }
-
   get latestPersonAppearance() {
-    return this.personAppearancesSortedByYear[this.personAppearancesSortedByYear.length - 1];
+    return this.personAppearances[this.personAppearances.length - 1];
   }
 
   get sourceYearRange() {
@@ -46,12 +34,12 @@ export class LifeCourseItemComponent implements OnInit {
   }
 
   get birthPlace() {
-    const firstPaWithBirthPlace = this.personAppearancesSortedByYear.find((pa) => pa.birthplace_display);
+    const firstPaWithBirthPlace = this.personAppearances.find((pa) => pa.birthplace_display);
     return firstPaWithBirthPlace ? firstPaWithBirthPlace.birthplace_display : "";
   }
 
   get birthYear() {
-    const firstPaWithBirthYear = this.personAppearancesSortedByYear.find((pa) => pa.birthyear_display);
+    const firstPaWithBirthYear = this.personAppearances.find((pa) => pa.birthyear_display);
     return firstPaWithBirthYear ? firstPaWithBirthYear.birthyear_display : "";
   }
 
@@ -65,6 +53,15 @@ export class LifeCourseItemComponent implements OnInit {
 
   constructor() { }
 
-  ngOnInit(): void {
+  ngOnChanges(): void {
+    this.personAppearances = [ ...this._pas ].sort(function(a, b) {
+      if (a.event_year_display > b.event_year_display) {
+        return 1;
+      }
+      if (a.event_year_display < b.event_year_display) {
+        return -1;
+      }
+      return 0;
+    });
   }
 }

--- a/src/app/life-course/life-course.component.ts
+++ b/src/app/life-course/life-course.component.ts
@@ -11,7 +11,6 @@ import { ElasticsearchService } from '../elasticsearch/elasticsearch.service';
   templateUrl: './life-course.component.html',
 })
 export class LifeCourseComponent implements OnInit {
-
   pas: PersonAppearance[] = [];
   lifecourseKey: string;
   links: Link[];
@@ -32,23 +31,8 @@ export class LifeCourseComponent implements OnInit {
     return this.config.aboutLifeCourseText;
   }
 
-  get personAppearancesSortedByYear() {
-    //TODO: this is destructive and changes the sorting of pas permanently, even when not accessing through this.
-    //      should it be an on-init thing instead?
-    const sortedByYear = this.pas.sort(function(a, b) {
-      if (a.event_year_display > b.event_year_display) {
-        return 1;
-      }
-      if (a.event_year_display < b.event_year_display) {
-        return -1;
-      }
-      return 0;
-    });
-    return sortedByYear;
-  }
-
   get latestPersonAppearance() {
-    return this.personAppearancesSortedByYear[this.personAppearancesSortedByYear.length - 1];
+    return this.pas[this.pas.length - 1];
   }
 
   get personName() {
@@ -56,12 +40,12 @@ export class LifeCourseComponent implements OnInit {
   }
 
   get birthPlace() {
-    const firstPaWithBirthPlace = this.personAppearancesSortedByYear.find((pa) => pa.birthplace_display);
+    const firstPaWithBirthPlace = this.pas.find((pa) => pa.birthplace_display);
     return firstPaWithBirthPlace ? firstPaWithBirthPlace.birthplace_display : "";
   }
 
   get birthYear() {
-    const firstPaWithBirthYear = this.personAppearancesSortedByYear.find((pa) => pa.birthyear_display);
+    const firstPaWithBirthYear = this.pas.find((pa) => pa.birthyear_display);
     return firstPaWithBirthYear ? firstPaWithBirthYear.birthyear_display : "";
   }
 
@@ -91,7 +75,17 @@ export class LifeCourseComponent implements OnInit {
 
   ngOnInit(): void {
     this.route.data.subscribe(next => {
-      this.pas = next.lifecourse.personAppearances as PersonAppearance[];
+      // Sort person appearances by event year
+      this.pas = next.lifecourse.personAppearances.sort(function(a, b) {
+        if (a.event_year_display > b.event_year_display) {
+          return 1;
+        }
+        if (a.event_year_display < b.event_year_display) {
+          return -1;
+        }
+        return 0;
+      }) as PersonAppearance[];
+
       this.lifecourseKey = next.lifecourse.lifecourseKey;
       this.links = next.lifecourse.links;
 


### PR DESCRIPTION
In life courses, the list of person appearances is in some cases sorting-independent and in other cases requires sorting chronologically by event year.

This PR replaces the implementation where the sorting happened on every execution of a getter (quite often!) with implementations that limit the sorting to happen on load.