### PR TITLE
Tweak source card UI size

### DIFF
--- a/src/app/life-course/life-course-item.component.html
+++ b/src/app/life-course/life-course-item.component.html
@@ -1,5 +1,8 @@
 <div class="lls-source lls-source--lifecourse">
     <div class="lls-source__header lls-source__section">
+        <div class="lls-source__symbol">
+            <svg class="lls-icon" />
+        </div>
         <h3 class="lls-source__title">Livsforløb</h3>
         <p class="u-margin-0">{{ sourceYearRange }}</p>
     </div>

--- a/src/app/life-course/life-course-item.component.html
+++ b/src/app/life-course/life-course-item.component.html
@@ -30,7 +30,7 @@
             {{ birthPlace }}
         </div>
     </div>
-    <div class="lls-source__section">
+    <div class="lls-source__section lls-source__person-data">
         <p class="lls-source__subtitle">Kilder</p>
         <p class="u-margin-0">{{ personAppearances.length }} {{ personAppearances.length != 1 ? "personregistreringer" : "personregistrering" }} i perioden {{ sourceYearRange }}.</p>
         <p class="u-margin-0" [innerHTML]="sourceList"></p>

--- a/src/app/life-course/life-course-item.component.html
+++ b/src/app/life-course/life-course-item.component.html
@@ -4,7 +4,7 @@
         <p class="u-margin-0">{{ sourceYearRange }}</p>
     </div>
 
-    <div class="lls-source__section lls-source__section--bordered">
+    <div class="lls-source__person-data lls-source__section lls-source__section--bordered">
         <p class="lls-source__subtitle u-text-capitalize">Person</p>
         <p class="lls-source__person u-bold u-text-capitalize">
             {{ personName }}

--- a/src/app/life-course/life-course-item.component.html
+++ b/src/app/life-course/life-course-item.component.html
@@ -1,11 +1,5 @@
 <div class="lls-source lls-source--lifecourse">
     <div class="lls-source__header lls-source__section">
-        <div class="lls-source__symbol">
-            <div class="lls-source__count">
-                <span class="lls-source__count-number">{{ personAppearances.length }}</span>
-            </div>
-            <span class="lls-source__count-text">{{ personAppearances.length != 1 ? "personregistreringer" : "personregistrering" }}</span>
-        </div>
         <h3 class="lls-source__title">Livsforløb</h3>
         <p class="u-margin-0">{{ sourceYearRange }}</p>
     </div>

--- a/src/app/person-appearance/person-appearance-item.component.html
+++ b/src/app/person-appearance/person-appearance-item.component.html
@@ -13,7 +13,7 @@
         </p>
     </div>
     
-    <div class="lls-source__section lls-source__section--bordered">
+    <div class="lls-source__person-data lls-source__section lls-source__section--bordered">
         <p class="lls-source__subtitle u-text-capitalize" *ngIf="personAppearance.role_display">
             {{ personAppearance.role_display }}
         </p>

--- a/src/app/person-appearance/person-appearance-item.component.html
+++ b/src/app/person-appearance/person-appearance-item.component.html
@@ -47,7 +47,7 @@
         </p>
     </div>
 
-    <div class="lls-source__section">
+    <div class="lls-source__section lls-source__person-data">
         <p class="lls-source__subtitle">Registrering</p>
         <p class="u-margin-0">
             {{ personAppearance.source_type_display }} {{ personAppearance.source_year_display }}

--- a/src/assets/styling/source-card.scss
+++ b/src/assets/styling/source-card.scss
@@ -179,6 +179,14 @@
     margin-right: 0;
     margin-bottom: 20px;
   }
+
+  .lls-source--lifecourse & {
+    display: none;
+
+    @media(min-width: $breakpointMd) {
+      display: flex;
+    }
+  }
 }
 
 .lls-source__subtitle {

--- a/src/assets/styling/source-card.scss
+++ b/src/assets/styling/source-card.scss
@@ -105,7 +105,7 @@
   box-sizing: border-box;
 
   @media(min-width: $breakpointMd) {
-    flex-basis: 25%;
+    flex-basis: 20%;
   }
 }
 
@@ -149,7 +149,7 @@
 
   @media(min-width: $breakpointMd) {
     display: block;
-    flex-basis: 20%;
+    max-width: 200px;
   }
 }
 

--- a/src/assets/styling/source-card.scss
+++ b/src/assets/styling/source-card.scss
@@ -181,30 +181,6 @@
   }
 }
 
-.lls-source__count {
-  display: flex;
-  height: 25px;
-  width: 25px;
-  border: 2px solid white;
-  border-radius: 50%;
-  align-items: center;
-  justify-content: center;
-  margin-bottom: 0;
-}
-
-.lls-source__count-number {
-  transform: translateY(-2px);
-}
-
-.lls-source__count-text {
-  display: none;
-
-  @media(min-width: $breakpointMd) {
-    display: block;
-    margin-left: 0.5rem;
-  }
-}
-
 .lls-source__subtitle {
   font-size: 16px;
   color: $grey--light;

--- a/src/assets/styling/source-card.scss
+++ b/src/assets/styling/source-card.scss
@@ -152,9 +152,16 @@
 .lls-source__header {
   display: flex;
   align-items: center;
-
+  
   @media(min-width: $breakpointMd) {
     display: block;
+    width: calc(20% - 4px);
+  }
+}
+
+.lls-source__person-data {
+  @media(min-width: $breakpointMd) {
+    width: calc(30% - 4px);
   }
 }
 

--- a/src/assets/styling/source-card.scss
+++ b/src/assets/styling/source-card.scss
@@ -100,11 +100,12 @@
 
 .lls-source__section {
   padding: 24px 20px;
-  width: 100%;
+  flex-basis: 100%;
+  flex-grow: 1;
   box-sizing: border-box;
 
   @media(min-width: $breakpointMd) {
-    width: calc(25% - 4px);
+    flex-basis: 25%;
   }
 }
 
@@ -148,13 +149,14 @@
 
   @media(min-width: $breakpointMd) {
     display: block;
-    width: calc(20% - 4px);
+    flex-basis: 20%;
   }
 }
 
 .lls-source__person-data {
   @media(min-width: $breakpointMd) {
-    width: calc(30% - 4px);
+    flex-basis: 30%;
+    flex-grow: 2;
   }
 }
 

--- a/src/assets/styling/source-card.scss
+++ b/src/assets/styling/source-card.scss
@@ -152,7 +152,7 @@
 .lls-source__header {
   display: flex;
   align-items: center;
-  
+
   @media(min-width: $breakpointMd) {
     display: block;
     width: calc(20% - 4px);


### PR DESCRIPTION
Trello: https://trello.com/c/HlmUUQG2/237-designjustering-p%C3%A5-s%C3%B8geresultat

Toggl: `Designjustering på søgeresultat`

### Changes:
- Update UI as per Signes request.
- The "person-data" section has 5% more width and the header section 5% less.

We could make more for the important data by shrinking the CTA section. I will reach out to signe and ask if this is something we want.

### Screenshots:
![image](https://user-images.githubusercontent.com/8166831/140044668-566070a4-eacd-48e0-a413-af5b556e7754.png)


### Problem discorvered:
![image](https://user-images.githubusercontent.com/8166831/140052530-d0981a22-5972-4930-9081-bd943afc268a.png)

The changes makes the lifecourse interface with links very bad on smaller screens, and we should fix it. I think a quickfix could be to remove the link-graph on tablet size.