### PR TITLE
Change subtitle text on lifecourse source card

### DIFF
--- a/src/app/life-course/life-course-item.component.html
+++ b/src/app/life-course/life-course-item.component.html
@@ -34,7 +34,7 @@
         </div>
     </div>
     <div class="lls-source__section">
-        <p class="lls-source__subtitle">Personregistreringer</p>
+        <p class="lls-source__subtitle">Kilder</p>
         <p class="u-margin-0">{{ personAppearances.length }} {{ personAppearances.length != 1 ? "personregistreringer" : "personregistrering" }} i perioden {{ sourceYearRange }}.</p>
         <p class="u-margin-0" [innerHTML]="sourceList"></p>
     </div>


### PR DESCRIPTION
Trello: https://trello.com/c/bppDyN3f/228-personregistreringer-%C3%A6ndres-til-kilder-i-bl%C3%A5-bokse-i-s%C3%B8geresultat

Toggl: `Personregistreringer ændres til Kilder i blå bokse i søgeresultat`

### Changes:
- Change "personregisteringer" to "kilder".

![image](https://user-images.githubusercontent.com/8166831/140063259-aecc5c00-2991-4557-9094-c72674faf1f5.png)
