### PR TITLE
Update source graph tooltip

### DIFF
--- a/src/app/elasticsearch/elasticsearch.service.ts
+++ b/src/app/elasticsearch/elasticsearch.service.ts
@@ -119,6 +119,7 @@ export interface Link {
   method_subtype1: string,
   score: number,
   key: string,
+  ratings: Array<object>,
 }
 
 export interface LinksSearchResult {

--- a/src/app/life-course/life-course.component.html
+++ b/src/app/life-course/life-course.component.html
@@ -73,6 +73,7 @@
             <app-source-linking-graph
                 [pas]="pas"
                 [links]="links"
+                [totalRatings]="totalRatings"
                 (openLinkRating)="openLinkRating($event)"
             ></app-source-linking-graph>
         </section>

--- a/src/app/life-course/life-course.component.html
+++ b/src/app/life-course/life-course.component.html
@@ -73,7 +73,6 @@
             <app-source-linking-graph
                 [pas]="pas"
                 [links]="links"
-                [totalRatings]="totalRatings"
                 (openLinkRating)="openLinkRating($event)"
             ></app-source-linking-graph>
         </section>

--- a/src/app/life-course/source-linking-graph.component.html
+++ b/src/app/life-course/source-linking-graph.component.html
@@ -71,7 +71,7 @@
             Giv feedback
         </button>
         <div class="u-mt-2">
-            {{totalRatings}} {{ totalRatings != 1 ? "personer" : "person" }} har givet feedback på dette link
+            {{ link.totalRatings }} {{ link.totalRatings != 1 ? "personer" : "person" }} har givet feedback på dette link
         </div>
     </div>
 </div>

--- a/src/app/life-course/source-linking-graph.component.html
+++ b/src/app/life-course/source-linking-graph.component.html
@@ -45,11 +45,11 @@
         class="lls-source-graph__tooltip"
         [class]="activeLink === link.key ? 'lls-source-graph__tooltip--active' : ''"
         *ngFor="let link of drawableLinks; index as i;"
-        [style]="'top: ' + (link.offsetY + (link.lineHeight / 2) - 208) + 'px; left: ' + (link.pathTierX + 29) + 'px;'"
+        [style]="'top: ' + (link.offsetY + (link.lineHeight / 2) - 269) + 'px; left: ' + (link.pathTierX + 30) + 'px;'"
         (mouseenter)="onMouseEnterTooltip(link.key)"
         (mouseleave)="onMouseLeaveTooltip(link.key)"
     >
-        <div class="lls-source-graph__tooltip-text lls-source-graph__tooltip-text--large u-bold">
+        <div class="lls-source-graph__tooltip-text lls-source-graph__tooltip-text--large u-bold u-mt-0">
             Om dette link
         </div>
         <div

--- a/src/app/life-course/source-linking-graph.component.html
+++ b/src/app/life-course/source-linking-graph.component.html
@@ -49,26 +49,29 @@
         (mouseenter)="onMouseEnterTooltip(link.key)"
         (mouseleave)="onMouseLeaveTooltip(link.key)"
     >
-        <div class="lls-source-graph__tooltip-label">
-            Sikkerhed
-        </div>
-        <div class="lls-source-graph__tooltip-text lls-source-graph__tooltip-text--large">
-            {{ link.confidencePct }}%
+        <div class="lls-source-graph__tooltip-text lls-source-graph__tooltip-text--large u-bold">
+            Om dette link
         </div>
         <div
             class="lls-source-graph__tooltip-text"
             [attr.title]="link.linkingMethod.long"
         >
-            Linket via<br>
+            Linket er skabt med metoden<br>
             {{ link.linkingMethod.short }}
         </div>
-        <button class="lls-btn lls-btn--small lls-btn--blue u-mt-2" (click)="openLinkRating.emit(link.key)">
-            Er linket troværdigt?
-        </button>
         <div class="u-mt-2">
-            <a class="lls-link lls-link--white" href="https://link-lives.dk/saadan-skabes-livsforloeb/">
+            <a class="lls-link lls-link--underline lls-link--white" href="https://link-lives.dk/saadan-skabes-livsforloeb/">
                 Læs mere om metoder til linkning
             </a>
+        </div>
+        <div class="u-mt-2 mb-2 u-bold">
+            Er linket troværdigt?
+        </div>
+        <button class="lls-btn lls-btn--small lls-btn--blue" (click)="openLinkRating.emit(link.key)">
+            Giv feedback
+        </button>
+        <div class="u-mt-2">
+            {{totalRatings}} {{ totalRatings != 1 ? "personer" : "person" }} har givet feedback på dette link
         </div>
     </div>
 </div>

--- a/src/app/life-course/source-linking-graph.component.html
+++ b/src/app/life-course/source-linking-graph.component.html
@@ -45,7 +45,7 @@
         class="lls-source-graph__tooltip"
         [class]="activeLink === link.key ? 'lls-source-graph__tooltip--active' : ''"
         *ngFor="let link of drawableLinks; index as i;"
-        [style]="'top: ' + (link.offsetY + (link.lineHeight / 2) - 269) + 'px; left: ' + (link.pathTierX + 30) + 'px;'"
+        [style]="'top: ' + (link.offsetY + (link.lineHeight / 2) - 271) + 'px; left: ' + (link.pathTierX + 30) + 'px;'"
         (mouseenter)="onMouseEnterTooltip(link.key)"
         (mouseleave)="onMouseLeaveTooltip(link.key)"
     >

--- a/src/app/life-course/source-linking-graph.component.ts
+++ b/src/app/life-course/source-linking-graph.component.ts
@@ -1,5 +1,5 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
-import { Link } from '../elasticsearch/elasticsearch.service';
+import { ElasticsearchService, Link } from '../elasticsearch/elasticsearch.service';
 import { PersonAppearance } from '../search/search.service';
 
 @Component({
@@ -10,6 +10,7 @@ export class SourceLinkingGraphComponent implements OnInit {
 
   @Input() pas: PersonAppearance[] = [];
   @Input() links: Link[] = [];
+  @Input() totalRatings: number;
 
   @Output()
   openLinkRating: EventEmitter<string> = new EventEmitter<string>();
@@ -122,7 +123,7 @@ export class SourceLinkingGraphComponent implements OnInit {
       });
   }
 
-  constructor() { }
+  constructor(private elasticsearch: ElasticsearchService) { }
 
   ngOnInit(): void {
     this.drawableLinks = this.calculateDrawableLinks();
@@ -130,6 +131,9 @@ export class SourceLinkingGraphComponent implements OnInit {
 
   onMouseEnterLink(key) {
     this.hoveredLink = key;
+    this.elasticsearch.getLinkRatingStats(key).subscribe(linkRatingData => {
+      this.totalRatings = linkRatingData.totalRatings
+    });
   }
 
   onMouseLeaveLink(key) {

--- a/src/app/life-course/source-linking-graph.component.ts
+++ b/src/app/life-course/source-linking-graph.component.ts
@@ -124,8 +124,6 @@ export class SourceLinkingGraphComponent implements OnInit {
       });
   }
 
-  constructor(private elasticsearch: ElasticsearchService) { }
-
   ngOnInit(): void {
     this.drawableLinks = this.calculateDrawableLinks();
   }

--- a/src/app/life-course/source-linking-graph.component.ts
+++ b/src/app/life-course/source-linking-graph.component.ts
@@ -10,7 +10,6 @@ export class SourceLinkingGraphComponent implements OnInit {
 
   @Input() pas: PersonAppearance[] = [];
   @Input() links: Link[] = [];
-  @Input() totalRatings: number;
 
   @Output()
   openLinkRating: EventEmitter<string> = new EventEmitter<string>();
@@ -21,6 +20,7 @@ export class SourceLinkingGraphComponent implements OnInit {
     lineHeight: number,
     confidencePct: number,
     linkingMethod: { long: string, short: string },
+    totalRatings: number,
     key: string,
   }[] = [];
 
@@ -108,6 +108,7 @@ export class SourceLinkingGraphComponent implements OnInit {
           lineHeight,
           confidencePct: Math.round((1 - link.score) * 100),
           linkingMethod: prettyLinkMethod(link),
+          totalRatings: link.ratings.length,
           key: link.key,
         };
       })
@@ -131,9 +132,6 @@ export class SourceLinkingGraphComponent implements OnInit {
 
   onMouseEnterLink(key) {
     this.hoveredLink = key;
-    this.elasticsearch.getLinkRatingStats(key).subscribe(linkRatingData => {
-      this.totalRatings = linkRatingData.totalRatings
-    });
   }
 
   onMouseLeaveLink(key) {

--- a/src/assets/styling/link.scss
+++ b/src/assets/styling/link.scss
@@ -15,6 +15,11 @@
   }
 }
 
+.lls-link--underline {
+  border-bottom-color: currentColor;
+  text-decoration: none;
+}
+
 .lls-link--white {
   color: white;
 

--- a/src/assets/styling/source-graph.scss
+++ b/src/assets/styling/source-graph.scss
@@ -106,6 +106,7 @@
   transition: opacity 0.4s;
   background: rgb(6, 40, 81);
   width: 240px;
+  height: 265px;
   position: absolute;
   border-radius: 3px;
   z-index: 10;

--- a/src/assets/styling/source-graph.scss
+++ b/src/assets/styling/source-graph.scss
@@ -104,10 +104,9 @@
   padding: 10px;
   opacity: 0;
   transition: opacity 0.4s;
-  font-weight: bold;
   background: rgb(6, 40, 81);
   width: 240px;
-  height: 200px;
+  height: 245px;
   position: absolute;
   border-radius: 3px;
   z-index: 10;
@@ -138,5 +137,9 @@
   margin: 0.5rem 0;
 }
 .lls-source-graph__tooltip-text--large {
-  font-size: 2rem;
+  font-size: 1.5rem;
+}
+
+.lls-source-graph__tooltip-text--bold {
+  font-weight: 500;
 }

--- a/src/assets/styling/source-graph.scss
+++ b/src/assets/styling/source-graph.scss
@@ -101,12 +101,11 @@
   font-size: 0.9rem;
   color: white;
   text-align: center;
-  padding: 10px;
+  padding: 20px;
   opacity: 0;
   transition: opacity 0.4s;
   background: rgb(6, 40, 81);
   width: 240px;
-  height: 245px;
   position: absolute;
   border-radius: 3px;
   z-index: 10;

--- a/src/assets/styling/utility.scss
+++ b/src/assets/styling/utility.scss
@@ -47,6 +47,10 @@
   margin: 0 !important;
 }
 
+.u-mt-0 {
+  margin-top: 0 !important;
+}
+
 .u-mt-2 {
   margin-top: 0.625rem !important;
 }


### PR DESCRIPTION
Trello: https://trello.com/c/L6ngCzVG/238-nyt-design-og-tekst-p%C3%A5-bl%C3%A5-link-boks

Toggl: `Nyt design og tekst på blå link boks`

### Changes:
- Change text and tweak markup in source-graph-link tooltip.
- Set "totalRatings" variable when a link is hovered, since we need to show the number of ratings in the tooltip.

### Feedback needed:
The height of the tooltip had to be increased, and therefore the "pointy"-arrow is no longer centered on the "link-circle". I did not want to try to recalculate the top position that is in the frontend, since @hypesystem can figure it out instantly.

### Screenshot
![Screenshot from 2021-11-03 15-56-37](https://user-images.githubusercontent.com/8166831/140084840-f059b4f4-b744-4389-8c61-1363ed9c921a.png)
