### PR TITLE
Change search history link to a button look. 

### DIFF
--- a/src/app/life-course/life-course.component.html
+++ b/src/app/life-course/life-course.component.html
@@ -9,12 +9,12 @@
                 Tilbage til søgeresultat
             </a>
             <a
-                class="lls-data-page-header__utility-link"
+                class="lls-data-page-header__utility-link lls-btn"
                 (click)="openSearchHistory = true"
                 (keyup.enter)="openSearchHistory = true"
                 tabindex="0"
             >
-                Min søgehistorik
+                Søgehistorik
             </a>
         </div>
         <div class="lls-data-page-header__classification">

--- a/src/app/person-appearance/person-appearance.component.html
+++ b/src/app/person-appearance/person-appearance.component.html
@@ -16,12 +16,12 @@
                 Tilbage til søgeresultat
             </a>
             <a
-                class="lls-data-page-header__utility-link"
+                class="lls-data-page-header__utility-link lls-btn"
                 (click)="openSearchHistory = true"
                 (keyup.enter)="openSearchHistory = true"
                 tabindex="0"
             >
-                Min søgehistorik
+                Søgehistorik
             </a>
         </div>
         <div class="lls-data-page-header__classification">

--- a/src/assets/styling/button.scss
+++ b/src/assets/styling/button.scss
@@ -9,8 +9,9 @@
   border-radius: 2px;
   text-transform: uppercase;
   font-weight: 600;
-  font-size: 1rem;
+  font-size: 0.925rem;
   letter-spacing: 1.2px;
+  line-height: 1.5rem;
 
   &:hover {
     background-color: lighten(#000, 5%);

--- a/src/assets/styling/data-page-header.scss
+++ b/src/assets/styling/data-page-header.scss
@@ -47,7 +47,7 @@
   cursor: pointer;
   white-space: nowrap;
   display: inline-block;
-  margin-right: 0.625rem;
+  margin-right: 1.125rem;
 
   @media(min-width: $breakpointSm) {
     &:last-child {

--- a/src/assets/styling/data-page-header.scss
+++ b/src/assets/styling/data-page-header.scss
@@ -54,8 +54,4 @@
       margin-right: 0;
     }
   }
-
-  @media(max-width: $breakpointSm) {
-    display: block;
-  }
 }

--- a/src/assets/styling/source-card.scss
+++ b/src/assets/styling/source-card.scss
@@ -120,13 +120,6 @@
     justify-content: flex-end;
     padding-left: 0;
   }
-
-  // Quickfix: Make sure that the CTA button text does not have linebreaks on tablet
-  .lls-btn {
-    @media(min-width: $breakpointMd) and (max-width: $breakpointLg) {
-      font-size: 0.9rem;
-    }
-  }
 }
 
 .lls-source__section--bordered {


### PR DESCRIPTION
Trello: https://trello.com/c/9F3y3Jh5/241-knap-design-p%C3%A5-s%C3%B8gehistorik

Toggl: `Knap design på søgehistorik`

### Changes:
- Change search history link to a button look.
- Also remove Min from the button text

Nb: Haven't done much to improve the mobile view. I feel like we need to reconsider the "back-link" and "back-to-lifecourse" link.

### Screenshot:
![image](https://user-images.githubusercontent.com/8166831/140095454-86f5332a-fe6e-44de-a8f1-011dc5e02ee3.png)
![image](https://user-images.githubusercontent.com/8166831/140095472-a8d15047-4aae-469e-b94e-cfba03bfbb0d.png)
