### PR TITLE
Lifecourse id update

### DIFF
--- a/src/app/life-course/life-course.component.html
+++ b/src/app/life-course/life-course.component.html
@@ -59,9 +59,21 @@
         [featherIconPath]="featherSpriteUrl"
         (close)="currentLinkKey = ''"
     ></app-link-rating>
+    <div class="lls-row my-4">
+        <h3 class="lls-columns-12 lls-columns-6--md u-margin-0 u-align-end">Personregistreringer</h3>
+        <div class="lls-source-info lls-columns-12 lls-columns-6--md">
+            <div class="lls-source-info__entry">
+                <div class="lls-source-info__entry-label">Forløbs ID</div>
+                <span>{{ lifecourseKey }}</span>
+            </div>
+            <div class="lls-source-info__entry">
+                <div class="lls-source-info__entry-label">Senest opdateret</div>
+                <span>{{ lastUpdated }}</span>
+            </div>
+        </div>
+    </div>
     <div class="lls-life-course-source-container">
         <section class="lls-life-course-source-container__source-list lls-row">
-            <h3 class="lls-columns-12 u-margin-0">Personregistreringer</h3>
             <app-person-appearance-item
                 *ngFor="let pa of pas"
                 class="lls-columns-12"
@@ -78,20 +90,6 @@
         </section>
     </div>
     <section>
-        <div class="lls-data-page-footer">
-            <div class="lls-data-page-footer__entry">
-                <div class="lls-data-page-footer__entry-label">
-                    Forløbs ID
-                </div>
-                <a [href]="'life-course/' + lifecourseKey">{{ lifecourseKey }}</a>
-            </div>
-            <div class="lls-data-page-footer__entry">
-                <div class="lls-data-page-footer__entry-label">
-                    Senest opdateret
-                </div>
-                <p>{{ lastUpdated }}</p>
-            </div>
-        </div>
         <div class="lls-data-page-footer">
             <div class="lls-data-page-footer__entry">
                 <h3 class="lls-data-page-footer__entry-label">

--- a/src/app/life-course/life-course.component.html
+++ b/src/app/life-course/life-course.component.html
@@ -60,7 +60,7 @@
         (close)="currentLinkKey = ''"
     ></app-link-rating>
     <div class="lls-row my-4">
-        <h3 class="lls-columns-12 lls-columns-6--md u-margin-0 u-align-end">Personregistreringer</h3>
+        <div class="lls-columns-12 lls-columns-6--md"></div>
         <div class="lls-source-info lls-columns-12 lls-columns-6--md">
             <div class="lls-source-info__entry">
                 <div class="lls-source-info__entry-label">Forløbs ID</div>
@@ -74,6 +74,7 @@
     </div>
     <div class="lls-life-course-source-container">
         <section class="lls-life-course-source-container__source-list lls-row">
+            <h3 class="lls-columns-12 u-margin-0">Personregistreringer</h3>
             <app-person-appearance-item
                 *ngFor="let pa of pas"
                 class="lls-columns-12"

--- a/src/app/life-course/life-course.component.html
+++ b/src/app/life-course/life-course.component.html
@@ -97,9 +97,9 @@
         </section>
     </div>
     <section>
-        <div class="lls-data-page-footer">
-            <div class="lls-data-page-footer__entry">
-                <h3 class="lls-data-page-footer__entry-label">
+        <div class="lls-source-info">
+            <div class="lls-source-info__entry">
+                <h3 class="lls-source-info__entry-label">
                     Om livsforløb
                 </h3>
                 <div [innerHTML]="aboutLifeCourseText"></div>

--- a/src/assets/styling/life-course-page.scss
+++ b/src/assets/styling/life-course-page.scss
@@ -28,7 +28,7 @@
   width: 320px;
   height: 100%;
   display: none;
-  margin-top: 3.625rem;
+  margin-top: 0.7rem;
 
   @media(min-width: $breakpointMd) {
     display: block;

--- a/src/assets/styling/life-course-page.scss
+++ b/src/assets/styling/life-course-page.scss
@@ -28,7 +28,6 @@
   width: 320px;
   height: 100%;
   display: none;
-  margin-top: 0.7rem;
 
   @media(min-width: $breakpointMd) {
     display: block;

--- a/src/assets/styling/utility.scss
+++ b/src/assets/styling/utility.scss
@@ -139,6 +139,10 @@
   }
 }
 
+.u-align-end {
+  align-self: flex-end;
+}
+
 .u-direction-row {
   flex-direction: row
 }


### PR DESCRIPTION
Based on #236 - adds the new layout of lifecourse ID to the lifecourse page.

![image](https://user-images.githubusercontent.com/859106/142617225-f7759d74-78f4-446d-bcc2-5f4ec1f38ccf.png)
