### PR TITLE
Add spacing to about lifecourse text

### DIFF
--- a/src/app/life-course/life-course.component.html
+++ b/src/app/life-course/life-course.component.html
@@ -96,7 +96,7 @@
             ></app-source-linking-graph>
         </section>
     </div>
-    <section>
+    <section class="u-mt-4">
         <div class="lls-source-info">
             <div class="lls-source-info__entry">
                 <h3 class="lls-source-info__entry-label">

--- a/src/app/life-course/life-course.component.html
+++ b/src/app/life-course/life-course.component.html
@@ -81,6 +81,14 @@
                 [item]="pa"
                 truncatableName="true"
             ></app-person-appearance-item>
+            <div class="u-mt-4 lls-columns-12">
+                <div class="lls-source-info__entry">
+                    <h3 class="lls-source-info__entry-label">
+                        Om livsforløb
+                    </h3>
+                    <div [innerHTML]="aboutLifeCourseText"></div>
+                </div>
+            </div>
         </section>
         <section class="lls-life-course-source-container__source-linking-graph">
             <div class="lls-life-course-source-container__source-linking-title">
@@ -96,14 +104,4 @@
             ></app-source-linking-graph>
         </section>
     </div>
-    <section class="u-mt-4">
-        <div class="lls-source-info">
-            <div class="lls-source-info__entry">
-                <h3 class="lls-source-info__entry-label">
-                    Om livsforløb
-                </h3>
-                <div [innerHTML]="aboutLifeCourseText"></div>
-            </div>
-        </div>
-    </section>
 </div>


### PR DESCRIPTION
There were some problems with the text on medium and smaller screens.

![image](https://user-images.githubusercontent.com/8166831/143571880-da7ee821-d1dd-4b3a-80e2-79882d8ca9e8.png)
