### PR TITLE
Exclude dubious links

### DIFF
--- a/src/app/data/data.service.ts
+++ b/src/app/data/data.service.ts
@@ -273,9 +273,9 @@ export class DataService {
   searchAdvanced(
     query: AdvancedSearchQuery,
     indices: string[],
-    from: number, size:
-    number, sortBy:
-    string,
+    from: number,
+    size: number,
+    sortBy: string,
     sortOrder: string,
     sourceFilter: FilterIdentifier[],
     mode: string = "default",

--- a/src/app/data/data.service.ts
+++ b/src/app/data/data.service.ts
@@ -270,7 +270,17 @@ export class DataService {
     });
   }
 
-  searchAdvanced(query: AdvancedSearchQuery, indices: string[], from: number, size: number, sortBy: string, sortOrder: string, sourceFilter: FilterIdentifier[], mode: string = "default") {
+  searchAdvanced(
+    query: AdvancedSearchQuery,
+    indices: string[],
+    from: number, size:
+    number, sortBy:
+    string,
+    sortOrder: string,
+    sourceFilter: FilterIdentifier[],
+    mode: string = "default",
+    excludeDubiousLinks: boolean = false,
+  ) {
     if(indices.length < 1) {
       const emptySearchResult = new Observable<SearchResult>((observer) => {
         observer.next({
@@ -297,7 +307,7 @@ export class DataService {
 
     const sort = this.createSortClause(sortBy, sortOrder);
 
-    const { resultLookupQuery, sourceLookupQuery } = this.createQueries(query, sourceFilter, mode);
+    const { resultLookupQuery, sourceLookupQuery } = this.createQueries(query, sourceFilter, mode, excludeDubiousLinks);
 
     const body = {
       from: from,
@@ -382,7 +392,7 @@ export class DataService {
     return this.search(indices, body, filterBody);
   }
 
-  createQueries(query: AdvancedSearchQuery, sourceFilter: FilterIdentifier[], mode: string) {
+  createQueries(query: AdvancedSearchQuery, sourceFilter: FilterIdentifier[], mode: string, excludeDubiousLinks: boolean) {
     const queryIncludingNested = (key, fun) => [ fun(key), fun(`person_appearance.${key}`) ];
     const matchQ = (key, val) => queryIncludingNested(key, (key) => {
       return { match: { [key]: val } };
@@ -395,6 +405,17 @@ export class DataService {
     };
 
     const must = [];
+
+    if(excludeDubiousLinks) {
+      must.push({
+        bool: {
+          must_not: [
+            { range: { "links.duplicates": { gt: 1 } } },
+          ],
+        }
+      });
+    }
+
     let sourceLookupFilter = must;
 
     const addFreeTextQuery = (must, value) => {

--- a/src/app/search-history.ts
+++ b/src/app/search-history.ts
@@ -30,6 +30,7 @@ export interface SearchHistoryEntry {
   pagination?: SearchResultPagination,
   sort?: SearchResultSorting,
   mode?: string,
+  excludeDubiousLinks?: string,
 }
 
 export interface LifecourseSearchHistoryEntry {
@@ -155,6 +156,10 @@ export function getLatestSearchQuery() {
 
     if(entry.mode) {
       queryParams.mode = entry.mode;
+    }
+
+    if(entry.excludeDubiousLinks) {
+      queryParams.excludeDubiousLinks = entry.excludeDubiousLinks;
     }
 
     if(Array.isArray(entry.index)) {

--- a/src/app/search-result-list/search-result-list.component.html
+++ b/src/app/search-result-list/search-result-list.component.html
@@ -119,6 +119,15 @@
                         >
                         <span>Inkluder stavevariationer</span>
                     </label>
+                    <label class="lls-results-header__checkbox-container">
+                        <input
+                            [(ngModel)]="includeDubiousLinks"
+                            type="checkbox"
+                            class="lls-results-header__checkbox"
+                            name="includeDubiousLinks"
+                        >
+                        <span>Inkluder usikre links</span>
+                    </label>
                 </div>
             </div>
             <div class="lls-results-header__right-section lls-columns-12 lls-columns-3--md lls-columns-2--lg lls-columns-1--xl">

--- a/src/app/search-result-list/search-result-list.component.ts
+++ b/src/app/search-result-list/search-result-list.component.ts
@@ -60,6 +60,7 @@ export class SearchResultListComponent implements OnInit {
   sortAscending = false;
 
   modeFuzzy = false;
+  includeDubiousLinks = true;
 
   searchTerms = [];
   searchFieldPlaceholders = searchFieldPlaceholders;
@@ -221,6 +222,7 @@ export class SearchResultListComponent implements OnInit {
       this.sortAscending = this.sortBy === "relevance" ? sortOrder !== "asc" : sortOrder !== "desc";
 
       this.modeFuzzy = queryParamMap.get('mode') === "fuzzy";
+      this.includeDubiousLinks = queryParamMap.get('excludeDubiousLinks') !== 'true';
       const sourceFilters = queryParamMap.get('sourceFilter');
       if(sourceFilters) {
         this.sourceFilter = sourceFilters
@@ -347,6 +349,7 @@ export class SearchResultListComponent implements OnInit {
     return {
       ...this.queryParams,
       mode: this.modeFuzzy ? "fuzzy" : "default",
+      excludeDubiousLinks: this.includeDubiousLinks ? null : "true",
       size: this.pagination.size,
       pg: page,
     };
@@ -364,6 +367,7 @@ export class SearchResultListComponent implements OnInit {
         sortOrder: this.queryParams.sortOrder,
         sourceFilter: this.queryParams.sourceFilter,
         mode: this.modeFuzzy ? "fuzzy" : "default",
+        excludeDubiousLinks: this.includeDubiousLinks ? null : "true",
         pg: page || this.pagination.current || 1,
         size: this.pagination.size,
       },

--- a/src/app/search-result-list/search-result-resolver.service.ts
+++ b/src/app/search-result-list/search-result-resolver.service.ts
@@ -27,6 +27,7 @@ export class SearchResultResolverService implements Resolve<SearchResult> {
     }
 
     let mode: string = route.queryParamMap.get('mode') || 'default';
+    let excludeDubiousLinks: string = route.queryParamMap.get('excludeDubiousLinks') || "false";
     let sortBy: string = route.queryParamMap.get('sortBy') || "relevance";
     let sortOrder: "asc" | "desc" = route.queryParamMap.get('sortOrder') === "desc" ? "desc" : "asc";
     const sourceFilterRaw = route.queryParamMap.get("sourceFilter");
@@ -111,8 +112,9 @@ export class SearchResultResolverService implements Resolve<SearchResult> {
       pagination: { page, size },
       sort: { sortBy, sortOrder },
       mode,
+      excludeDubiousLinks,
     });
 
-    return this.service.advancedSearch(actualSearchTerms, index, (page - 1) * size, size, sortBy, sortOrder, sourceFilter, mode);
+    return this.service.advancedSearch(actualSearchTerms, index, (page - 1) * size, size, sortBy, sortOrder, sourceFilter, mode, excludeDubiousLinks);
   }
 }

--- a/src/app/search/search.service.ts
+++ b/src/app/search/search.service.ts
@@ -199,7 +199,28 @@ export class SearchService {
 
   constructor(private elasticsearch: DataService) { }
 
-  advancedSearch(query: AdvancedSearchQuery, indices: string[], from: number, size: number, sortBy: string, sortOrder: string, sourceFilter: FilterIdentifier[], mode: string = "default"): Observable<SearchResult> {
-    return this.elasticsearch.searchAdvanced(query, indices, from, size, sortBy, sortOrder, sourceFilter, mode);
+  advancedSearch(
+    query: AdvancedSearchQuery,
+    indices: string[],
+    from: number,
+    size: number,
+    sortBy: string,
+    sortOrder: string,
+    sourceFilter: FilterIdentifier[],
+    mode: string = "default",
+    excludeDubiousLinksString: string = "false"
+  ): Observable<SearchResult> {
+    const excludeDubiousLinks = excludeDubiousLinksString === "true";
+    return this.elasticsearch.searchAdvanced(
+      query,
+      indices,
+      from,
+      size,
+      sortBy,
+      sortOrder,
+      sourceFilter,
+      mode,
+      excludeDubiousLinks,
+    );
   }
 }

--- a/src/app/search/simple/search-simple.component.html
+++ b/src/app/search/simple/search-simple.component.html
@@ -182,15 +182,26 @@
         </div>
 
         <div class="u-flex u-space-between u-align-items u-mt-2">
-          <label class="lls-search-options__checkbox-container">
-            <input
-              [(ngModel)]="modeFuzzy"
-              type="checkbox"
-              class="lls-search-options__checkbox"
-              name="modeFuzzy"
-            >
-            <span>Inkluder stavevariationer i søgning</span>
-          </label>
+          <div>
+            <label class="lls-search-options__checkbox-container">
+              <input
+                [(ngModel)]="modeFuzzy"
+                type="checkbox"
+                class="lls-search-options__checkbox"
+                name="modeFuzzy"
+              >
+              <span>Inkluder stavevariationer i søgning</span>
+            </label>
+            <label class="lls-search-options__checkbox-container">
+              <input
+                [(ngModel)]="includeDubiousLinks"
+                type="checkbox"
+                class="lls-search-options__checkbox"
+                name="includeDubiousLinks"
+              >
+              <span>Inkluder livsforløb, der indeholder usikre links</span>
+            </label>
+          </div>
 
           <button
             type="submit"

--- a/src/app/search/simple/search-simple.component.ts
+++ b/src/app/search/simple/search-simple.component.ts
@@ -21,6 +21,7 @@ export class SimpleSearchComponent implements OnInit {
 
   // Advanced search
   modeFuzzy = false;
+  includeDubiousLinks = true;
   searchFieldPlaceholders = searchFieldPlaceholders;
   searchFieldLabels = searchFieldLabels;
 
@@ -141,6 +142,7 @@ export class SimpleSearchComponent implements OnInit {
         ...searchParams,
         index: this.computedIndex,
         mode: this.modeFuzzy ? "fuzzy" : "default",
+        excludeDubiousLinks: this.includeDubiousLinks ? null : "true",
       }
     });
   }

--- a/src/app/search/simple/search-simple.component.ts
+++ b/src/app/search/simple/search-simple.component.ts
@@ -132,6 +132,10 @@ export class SimpleSearchComponent implements OnInit {
       .filter((term) => term.value !== "")
       .forEach((term) => searchParams[term.field] = term.value);
 
+    if (Object.keys(searchParams).length === 0) {
+      searchParams.query = "";
+    }
+
     this.router.navigate(['/results'], {
       queryParams: {
         ...searchParams,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/859106/146738675-475f6356-1f5e-486e-8619-d4cea65de2c0.png)

![image](https://user-images.githubusercontent.com/859106/146738712-3420f6c8-822a-4994-aa7d-535df82acbec.png)

Adds checkbox default-true for including dubious links (where duplicates > 1). If the check mark is removed, we add the `excludeDubiousLinks=true` query param to searches. This then results in a "must not have links.duplicates greater than 1" addition to the query.

Also added it to the search history, so that should work.