### PR TITLE
Use id in linkrating api

### DIFF
--- a/src/app/data/data.service.ts
+++ b/src/app/data/data.service.ts
@@ -104,6 +104,7 @@ export interface Link {
   method_subtype1: string,
   score: number,
   key: string,
+  id: string,
   ratings: Array<object>,
   duplicates: number,
 }

--- a/src/app/data/rating.service.ts
+++ b/src/app/data/rating.service.ts
@@ -84,8 +84,8 @@ export class RatingService {
     return this.http.post<any>(`${environment.apiUrl}/LinkRating`, linkRating);
   }
 
-  getLinkRatingStats(key: string): Observable<{ headingRatings: any, totalRatings: number, ratedBy: string[] }> {
-    return this.http.get<any>(`${environment.apiUrl}/Link/${key}/ratings`)
+  getLinkRatingStats(id: string): Observable<{ headingRatings: any, totalRatings: number, ratedBy: string[] }> {
+    return this.http.get<any>(`${environment.apiUrl}/Link/${id}/ratings`)
       .pipe(map(((ratings) => {
         const headingRatings = {};
 

--- a/src/app/life-course/life-course-resolver.service.ts
+++ b/src/app/life-course/life-course-resolver.service.ts
@@ -13,9 +13,9 @@ export class LifeCourseResolverService implements Resolve<{lifecourseKey: string
 
   constructor(private elasticsearch: DataService) { }
 
-  resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<{ lifecourseKey: string; personAppearances: PersonAppearance[]; links: Link[]; currentLinkKey: string; chosenRatingId: string; lifecourseId: number; }> {
+  resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<{ lifecourseKey: string; personAppearances: PersonAppearance[]; links: Link[]; currentLinkId: string; chosenRatingId: string; lifecourseId: number; }> {
     const lifecourseKey = route.params.key;
-    const currentLinkKey = route.queryParamMap.get('currentLinkKey') || '';
+    const currentLinkId = route.queryParamMap.get('currentLinkId') || '';
     const chosenRatingId = route.queryParamMap.get('chosenRatingId') || '';
 
     return new Observable(
@@ -34,7 +34,7 @@ export class LifeCourseResolverService implements Resolve<{lifecourseKey: string
               lifecourseId: lifecourse.life_course_id,
               personAppearances: lifecourse.personAppearances,
               links: lifecourse.links,
-              currentLinkKey,
+              currentLinkId,
               chosenRatingId,
             };
           }

--- a/src/app/life-course/life-course-resolver.service.ts
+++ b/src/app/life-course/life-course-resolver.service.ts
@@ -18,36 +18,23 @@ export class LifeCourseResolverService implements Resolve<{lifecourseKey: string
     const currentLinkId = route.queryParamMap.get('currentLinkId') || '';
     const chosenRatingId = route.queryParamMap.get('chosenRatingId') || '';
 
-    return new Observable(
-      observer => {
-        this.elasticsearch.getLifecourse(lifecourseKey)
-          .pipe(map((lifecourse: Lifecourse, index) => {
-            addSearchHistoryEntry({
-              type: SearchHistoryEntryType.Lifecourse,
-              lifecourse: {
-                key: lifecourseKey,
-                personAppearances: lifecourse.personAppearances || [],
-              },
-            });
-            return {
-              lifecourseKey,
-              lifecourseId: lifecourse.life_course_id,
-              personAppearances: lifecourse.personAppearances,
-              links: lifecourse.links,
-              currentLinkId,
-              chosenRatingId,
-            };
-          }
-          ))
-          .subscribe(next => {
-            observer.next(next);
-          }, error => {
-            observer.error(error);
-          }, () => {
-            observer.complete();
-          }
-        )
-      }
-    );
+    return this.elasticsearch.getLifecourse(lifecourseKey)
+      .pipe(map((lifecourse: Lifecourse, index) => {
+        addSearchHistoryEntry({
+          type: SearchHistoryEntryType.Lifecourse,
+          lifecourse: {
+            key: lifecourseKey,
+            personAppearances: lifecourse.personAppearances || [],
+          },
+        });
+        return {
+          lifecourseKey,
+          lifecourseId: lifecourse.life_course_id,
+          personAppearances: lifecourse.personAppearances,
+          links: lifecourse.links,
+          currentLinkId,
+          chosenRatingId,
+        };
+      }));
   }
 }

--- a/src/app/life-course/life-course.component.html
+++ b/src/app/life-course/life-course.component.html
@@ -51,7 +51,6 @@
         (close)="openSearchHistory = false"
     ></app-search-history>
     <app-link-rating
-        [openLinkRating]="currentLinkId"
         [linkId]="currentLinkId"
         [chosenRatingId]="chosenRatingId"
         [totalRatings]="totalRatings"

--- a/src/app/life-course/life-course.component.html
+++ b/src/app/life-course/life-course.component.html
@@ -51,14 +51,14 @@
         (close)="openSearchHistory = false"
     ></app-search-history>
     <app-link-rating
-        [openLinkRating]="currentLinkKey"
-        [linkKey]="currentLinkKey"
+        [openLinkRating]="currentLinkId"
+        [linkId]="currentLinkId"
         [chosenRatingId]="chosenRatingId"
         [totalRatings]="totalRatings"
         [ratingCountByCategory]="ratingCountByCategory"
         [ratedBy]="ratedBy"
         [featherIconPath]="featherSpriteUrl"
-        (close)="currentLinkKey = ''"
+        (close)="currentLinkId = ''"
     ></app-link-rating>
     <div class="lls-row my-4">
         <div class="lls-columns-12 lls-columns-6--md"></div>

--- a/src/app/life-course/life-course.component.ts
+++ b/src/app/life-course/life-course.component.ts
@@ -78,9 +78,9 @@ export class LifeCourseComponent implements OnInit {
   constructor(private route: ActivatedRoute, private ratingService: RatingService) { }
 
   ngOnInit(): void {
-    this.route.data.subscribe(next => {
+    this.route.data.subscribe(({ lifecourse }) => {
       // Sort person appearances by event year
-      this.pas = next.lifecourse.personAppearances.sort(function(a, b) {
+      this.pas = lifecourse.personAppearances.sort(function(a, b) {
         if (a.event_year_display > b.event_year_display) {
           return 1;
         }
@@ -90,12 +90,12 @@ export class LifeCourseComponent implements OnInit {
         return 0;
       }) as PersonAppearance[];
 
-      this.lifecourseKey = next.lifecourse.lifecourseKey;
-      this.lifecourseId = next.lifecourse.lifecourseId;
-      this.links = next.lifecourse.links;
+      this.lifecourseKey = lifecourse.lifecourseKey;
+      this.lifecourseId = lifecourse.lifecourseId;
+      this.links = lifecourse.links;
 
-      if(next.lifecourse.currentLinkId) {
-        this.openLinkRating(next.lifecourse.currentLinkId, next.lifecourse.chosenRatingId);
+      if(lifecourse.currentLinkId) {
+        this.openLinkRating(lifecourse.currentLinkId, lifecourse.chosenRatingId);
       }
     });
   }

--- a/src/app/life-course/life-course.component.ts
+++ b/src/app/life-course/life-course.component.ts
@@ -23,7 +23,7 @@ export class LifeCourseComponent implements OnInit {
 
   featherSpriteUrl = this.config.featherIconPath;
   openSearchHistory: boolean = false;
-  currentLinkKey: string = "";
+  currentLinkId: string = "";
   chosenRatingId;
   totalRatings;
   ratingCountByCategory;
@@ -64,11 +64,11 @@ export class LifeCourseComponent implements OnInit {
     return prettyDate(date);
   }
 
-  openLinkRating(linkKey, chosenRatingId="") {
-    this.currentLinkKey = linkKey;
+  openLinkRating(linkId, chosenRatingId="") {
+    this.currentLinkId = linkId;
     this.chosenRatingId = chosenRatingId;
 
-    this.ratingService.getLinkRatingStats(linkKey).subscribe(({ totalRatings, headingRatings, ratedBy }) => {
+    this.ratingService.getLinkRatingStats(linkId).subscribe(({ totalRatings, headingRatings, ratedBy }) => {
       this.totalRatings = totalRatings;
       this.ratingCountByCategory = headingRatings;
       this.ratedBy = ratedBy;
@@ -94,8 +94,8 @@ export class LifeCourseComponent implements OnInit {
       this.lifecourseId = next.lifecourse.lifecourseId;
       this.links = next.lifecourse.links;
 
-      if(next.lifecourse.currentLinkKey) {
-        this.openLinkRating(next.lifecourse.currentLinkKey, next.lifecourse.chosenRatingId);
+      if(next.lifecourse.currentLinkId) {
+        this.openLinkRating(next.lifecourse.currentLinkId, next.lifecourse.chosenRatingId);
       }
     });
   }

--- a/src/app/life-course/source-linking-graph.component.html
+++ b/src/app/life-course/source-linking-graph.component.html
@@ -24,11 +24,11 @@
 
     <div
         class="lls-source-graph__link"
-        [class]="activeLink === link.key ? 'lls-source-graph__link--active' : ''"
+        [class]="activeLink === link.id ? 'lls-source-graph__link--active' : ''"
         *ngFor="let link of drawableLinks; index as i;"
         [style]="'top: ' + link.offsetY + 'px;'"
-        (mouseenter)="onMouseEnterLink(link.key)"
-        (mouseleave)="onMouseLeaveLink(link.key)"
+        (mouseenter)="onMouseEnterLink(link.id)"
+        (mouseleave)="onMouseLeaveLink(link.id)"
     >
         <div
             class="lls-source-graph__link-path"
@@ -44,11 +44,11 @@
 
     <div
         class="lls-source-graph__tooltip"
-        [class]="(activeLink === link.key ? 'lls-source-graph__tooltip--active' : '') + (link.duplicates ? ' lls-source-graph__tooltip--link-with-duplicates' : '')"
+        [class]="(activeLink === link.id ? 'lls-source-graph__tooltip--active' : '') + (link.duplicates ? ' lls-source-graph__tooltip--link-with-duplicates' : '')"
         *ngFor="let link of drawableLinks; index as i;"
         [style]="'top: ' + (link.offsetY + (link.lineHeight / 2) - (link.duplicates ? 326 : 271)) + 'px; left: ' + (link.pathTierX + 30) + 'px;'"
-        (mouseenter)="onMouseEnterTooltip(link.key)"
-        (mouseleave)="onMouseLeaveTooltip(link.key)"
+        (mouseenter)="onMouseEnterTooltip(link.id)"
+        (mouseleave)="onMouseLeaveTooltip(link.id)"
     >
         <div class="lls-source-graph__tooltip-text lls-source-graph__tooltip-text--large u-bold u-mt-0">
             Om dette link
@@ -71,7 +71,7 @@
         <div class="u-mt-2 mb-2 u-bold">
             Er linket troværdigt?
         </div>
-        <button class="lls-btn lls-btn--small lls-btn--blue" (click)="openLinkRating.emit(link.key)">
+        <button class="lls-btn lls-btn--small lls-btn--blue" (click)="openLinkRating.emit(link.id)">
             Giv feedback
         </button>
         <div class="u-mt-2">

--- a/src/app/life-course/source-linking-graph.component.ts
+++ b/src/app/life-course/source-linking-graph.component.ts
@@ -2,6 +2,17 @@ import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { Link } from '../data/data.service';
 import { PersonAppearance } from '../search/search.service';
 
+interface DrawableLink{
+  offsetY: number,
+  pathTierX: number,
+  lineHeight: number,
+  confidencePct: number,
+  linkingMethod: { long: string, short: string },
+  totalRatings: number,
+  id: string,
+  duplicates: number,
+};
+
 @Component({
   selector: 'app-source-linking-graph',
   templateUrl: './source-linking-graph.component.html',
@@ -14,16 +25,7 @@ export class SourceLinkingGraphComponent implements OnInit {
   @Output()
   openLinkRating: EventEmitter<string> = new EventEmitter<string>();
 
-  drawableLinks: {
-    offsetY: number,
-    pathTierX: number,
-    lineHeight: number,
-    confidencePct: number,
-    linkingMethod: { long: string, short: string },
-    totalRatings: number,
-    key: string,
-    duplicates: number,
-  }[] = [];
+  drawableLinks: DrawableLink[] = [];
 
   hoveredLink?: string = null;
   hoveredTooltip?: string = null;
@@ -36,7 +38,7 @@ export class SourceLinkingGraphComponent implements OnInit {
     return [ ...this.pas ].reverse();
   }
 
-  calculateDrawableLinks() {
+  calculateDrawableLinks(): DrawableLink[] {
     //These represent gaps, not PAs, so there is one less than there are PAs in order.
     const maxTiers = Array(this.pas.length - 1).fill(-1);
 
@@ -110,7 +112,7 @@ export class SourceLinkingGraphComponent implements OnInit {
           confidencePct: Math.round((1 - link.score) * 100),
           linkingMethod: prettyLinkMethod(link),
           totalRatings: link.ratings ? link.ratings.length : 0, // TODO: Remove this guarding when the link.rating data is fixed. Right now it can be null.
-          key: link.key,
+          id: link.id,
           duplicates: link.duplicates,
         };
       })
@@ -130,22 +132,22 @@ export class SourceLinkingGraphComponent implements OnInit {
     this.drawableLinks = this.calculateDrawableLinks();
   }
 
-  onMouseEnterLink(key) {
-    this.hoveredLink = key;
+  onMouseEnterLink(id) {
+    this.hoveredLink = id;
   }
 
-  onMouseLeaveLink(key) {
-    if(this.hoveredLink === key) {
+  onMouseLeaveLink(id) {
+    if(this.hoveredLink === id) {
       this.hoveredLink = null;
     }
   }
 
-  onMouseEnterTooltip(key) {
-    this.hoveredTooltip = key;
+  onMouseEnterTooltip(id) {
+    this.hoveredTooltip = id;
   }
 
-  onMouseLeaveTooltip(key) {
-    if(this.hoveredTooltip === key) {
+  onMouseLeaveTooltip(id) {
+    if(this.hoveredTooltip === id) {
       this.hoveredTooltip = null;
     }
   }

--- a/src/app/link-rating/component.ts
+++ b/src/app/link-rating/component.ts
@@ -14,7 +14,6 @@ import { UserManagementService } from '../user-management/service';
 })
 
 export class LinkRatingComponent implements OnInit {
-  @Input() openLinkRating: boolean;
   @Input() featherIconPath: string;
   @Input() linkId: string;
   @Input() totalRatings: number;
@@ -28,6 +27,10 @@ export class LinkRatingComponent implements OnInit {
   ratingOptions;
   currentPath = this.userManagement.currentPath();
   user;
+
+  get openLinkRating() {
+    return Boolean(this.linkId);
+  }
 
   get ratingCategoriesWithCount() {
     const result = {};
@@ -94,7 +97,7 @@ export class LinkRatingComponent implements OnInit {
   closeLinkRating() {
     this.showForm = true;
     this.chosen = "";
-    this.openLinkRating = false;
+    this.linkId = null;
     this.linkRatingForm.reset();
     // reset url query
     this.router.navigate([this.currentPath], {

--- a/src/app/link-rating/component.ts
+++ b/src/app/link-rating/component.ts
@@ -16,7 +16,7 @@ import { UserManagementService } from '../user-management/service';
 export class LinkRatingComponent implements OnInit {
   @Input() openLinkRating: boolean;
   @Input() featherIconPath: string;
-  @Input() linkKey: string;
+  @Input() linkId: string;
   @Input() totalRatings: number;
   @Input() ratingCountByCategory: any;
   @Input() ratedBy: string[];
@@ -65,7 +65,7 @@ export class LinkRatingComponent implements OnInit {
     const chosenRatingId = this.linkRatingForm.value.option;
     const ratingData = {
       ratingId: chosenRatingId,
-      linkKey: this.linkKey,
+      linkId: this.linkId,
     }
 
     const linkOption = this.ratingOptions.find(optionCategory => optionCategory.options.some(option => option.value == chosenRatingId));
@@ -108,7 +108,7 @@ export class LinkRatingComponent implements OnInit {
     // triggering a navigation event,
     this.router.navigate([this.currentPath], {
       queryParams: {
-        currentLinkKey: this.linkKey,
+        currentLinkId: this.linkId,
         chosenRatingId: this.linkRatingForm.value.option
       }
     }).then(() => {


### PR DESCRIPTION
The API has changed for `GET Link/:id/Rating{/stats,}` so these endpoints now use the link ID rather than the key (cf. [swagger](https://api-test.link-lives.dk/swagger/index.html)).

I have tried to make that clear in the code + cleaned up a bit on the way.