### PR TITLE
Person Apperance ID is called pa_id now. Also the one shown in the UI.

### DIFF
--- a/src/app/search-term-values.ts
+++ b/src/app/search-term-values.ts
@@ -2,7 +2,7 @@ import { Category, Option } from './form-elements/dropdown/component';
 
 export const mapSearchKeys = {
   id: {
-    exact: "id",
+    exact: "pa_id",
   },
   name: {
     default: "name_searchable",


### PR DESCRIPTION
Trello task: https://trello.com/c/SikeOpaW/299-s%C3%B8gning-p%C3%A5-personregistrerings-id-virker-ikke

Toggl label: `Søgning på personregistrerings ID virker ikke`

For some reason the `pa_id` is not unique in the current dataset. I find up to 4-5 of the same PA when searching for an ID.
Also the field `id` that we were searching for before, is always `0`. Weird, but I guess its just a mistake.