### PR TITLE
Add (KBH) to the burial_protocol event-type label in the filter

### DIFF
--- a/src/app/filter-sidebar/component.ts
+++ b/src/app/filter-sidebar/component.ts
@@ -94,7 +94,7 @@ export class FilterSidebar implements OnInit {
   eventCategories() {
     return this.possibleFilters.eventType.map(x => {
       return {
-        label: x.event_type_display,
+        label: x.event_type === "burial_protocol" ? `${x.event_type_display} (KBH)` : x.event_type_display,
         type: x.event_type,
         value: `eventType_${x.event_type}_${x.event_type_display}`,
         count: prettyNumbers(x.count),


### PR DESCRIPTION
Not sure we should do this, since we want the data from ES to be clean. I have written this to Signe and she will make a descision whether we should fix this in the frontend or indexed data.