### PR TITLE
Search unsafe links (round 2)

### DIFF
--- a/src/app/life-course/source-linking-graph.component.ts
+++ b/src/app/life-course/source-linking-graph.component.ts
@@ -2,7 +2,7 @@ import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { Link } from '../data/data.service';
 import { PersonAppearance } from '../search/search.service';
 
-interface DrawableLink{
+interface DrawableLink {
   offsetY: number,
   pathTierX: number,
   lineHeight: number,
@@ -10,7 +10,7 @@ interface DrawableLink{
   linkingMethod: { long: string, short: string },
   totalRatings: number,
   id: string,
-  duplicates: number,
+  duplicates: boolean,
 };
 
 @Component({

--- a/src/app/life-course/source-linking-graph.component.ts
+++ b/src/app/life-course/source-linking-graph.component.ts
@@ -113,7 +113,7 @@ export class SourceLinkingGraphComponent implements OnInit {
           linkingMethod: prettyLinkMethod(link),
           totalRatings: link.ratings ? link.ratings.length : 0, // TODO: Remove this guarding when the link.rating data is fixed. Right now it can be null.
           id: link.id,
-          duplicates: link.duplicates,
+          duplicates: link.duplicates > 1,
         };
       })
       .sort((a, b) => {

--- a/src/app/life-course/source-linking-graph.component.ts
+++ b/src/app/life-course/source-linking-graph.component.ts
@@ -82,7 +82,7 @@ export class SourceLinkingGraphComponent implements OnInit {
           if(method === "Manual") {
             return {
               short: "Manuelt",
-              long: "Manuelt skabt link af en peson i Link-Lives teamet.",
+              long: "Manuelt skabt link af en person i Link-Lives teamet.",
             };
           }
           if(method === "Rule Based" && subtype === "household") {

--- a/src/app/search-history.ts
+++ b/src/app/search-history.ts
@@ -31,6 +31,7 @@ export interface SearchHistoryEntry {
   sort?: SearchResultSorting,
   mode?: string,
   excludeDubiousLinks?: string,
+  excludeUndoubtedLinks?: string,
 }
 
 export interface LifecourseSearchHistoryEntry {
@@ -160,6 +161,10 @@ export function getLatestSearchQuery() {
 
     if(entry.excludeDubiousLinks) {
       queryParams.excludeDubiousLinks = entry.excludeDubiousLinks;
+    }
+
+    if(entry.excludeUndoubtedLinks) {
+      queryParams.excludeUndoubtedLinks = entry.excludeUndoubtedLinks;
     }
 
     if(Array.isArray(entry.index)) {

--- a/src/app/search-result-list/search-result-list.component.html
+++ b/src/app/search-result-list/search-result-list.component.html
@@ -128,6 +128,15 @@
                         >
                         <span>Inkluder usikre links</span>
                     </label>
+                    <label class="lls-results-header__checkbox-container">
+                        <input
+                            [(ngModel)]="includeUndoubtedLinks"
+                            type="checkbox"
+                            class="lls-results-header__checkbox"
+                            name="includeUndoubtedLinks"
+                        >
+                        <span>Inkluder sikre links</span>
+                    </label>
                 </div>
             </div>
             <div class="lls-results-header__right-section lls-columns-12 lls-columns-3--md lls-columns-2--lg lls-columns-1--xl">

--- a/src/app/search-result-list/search-result-list.component.ts
+++ b/src/app/search-result-list/search-result-list.component.ts
@@ -61,6 +61,7 @@ export class SearchResultListComponent implements OnInit {
 
   modeFuzzy = false;
   includeDubiousLinks = true;
+  includeUndoubtedLinks = true;
 
   searchTerms = [];
   searchFieldPlaceholders = searchFieldPlaceholders;
@@ -223,6 +224,7 @@ export class SearchResultListComponent implements OnInit {
 
       this.modeFuzzy = queryParamMap.get('mode') === "fuzzy";
       this.includeDubiousLinks = queryParamMap.get('excludeDubiousLinks') !== 'true';
+      this.includeUndoubtedLinks = queryParamMap.get('excludeUndoubtedLinks') !== 'true';
       const sourceFilters = queryParamMap.get('sourceFilter');
       if(sourceFilters) {
         this.sourceFilter = sourceFilters
@@ -350,6 +352,7 @@ export class SearchResultListComponent implements OnInit {
       ...this.queryParams,
       mode: this.modeFuzzy ? "fuzzy" : "default",
       excludeDubiousLinks: this.includeDubiousLinks ? null : "true",
+      excludeUndoubtedLinks: this.includeUndoubtedLinks ? null : "true",
       size: this.pagination.size,
       pg: page,
     };
@@ -368,6 +371,7 @@ export class SearchResultListComponent implements OnInit {
         sourceFilter: this.queryParams.sourceFilter,
         mode: this.modeFuzzy ? "fuzzy" : "default",
         excludeDubiousLinks: this.includeDubiousLinks ? null : "true",
+        excludeUndoubtedLinks: this.includeUndoubtedLinks ? null : "true",
         pg: page || this.pagination.current || 1,
         size: this.pagination.size,
       },

--- a/src/app/search-result-list/search-result-resolver.service.ts
+++ b/src/app/search-result-list/search-result-resolver.service.ts
@@ -28,6 +28,7 @@ export class SearchResultResolverService implements Resolve<SearchResult> {
 
     let mode: string = route.queryParamMap.get('mode') || 'default';
     let excludeDubiousLinks: string = route.queryParamMap.get('excludeDubiousLinks') || "false";
+    let excludeUndoubtedLinks: string = route.queryParamMap.get('excludeUndoubtedLinks') || "false";
     let sortBy: string = route.queryParamMap.get('sortBy') || "relevance";
     let sortOrder: "asc" | "desc" = route.queryParamMap.get('sortOrder') === "desc" ? "desc" : "asc";
     const sourceFilterRaw = route.queryParamMap.get("sourceFilter");
@@ -114,8 +115,9 @@ export class SearchResultResolverService implements Resolve<SearchResult> {
       sort: { sortBy, sortOrder },
       mode,
       excludeDubiousLinks,
+      excludeUndoubtedLinks,
     });
 
-    return this.service.advancedSearch(actualSearchTerms, index, (page - 1) * size, size, sortBy, sortOrder, sourceFilter, mode, excludeDubiousLinks);
+    return this.service.advancedSearch(actualSearchTerms, index, (page - 1) * size, size, sortBy, sortOrder, sourceFilter, mode, excludeDubiousLinks, excludeUndoubtedLinks);
   }
 }

--- a/src/app/search/search.service.ts
+++ b/src/app/search/search.service.ts
@@ -209,9 +209,11 @@ export class SearchService {
     sortOrder: string,
     sourceFilter: FilterIdentifier[],
     mode: string = "default",
-    excludeDubiousLinksString: string = "false"
+    excludeDubiousLinksString: string = "false",
+    excludeUndoubtedLinksString: string = "false",
   ): Observable<SearchResult> {
     const excludeDubiousLinks = excludeDubiousLinksString === "true";
+    const excludeUndoubtedLinks = excludeUndoubtedLinksString === "true";
     return this.elasticsearch.searchAdvanced(
       query,
       indices,
@@ -222,6 +224,7 @@ export class SearchService {
       sourceFilter,
       mode,
       excludeDubiousLinks,
+      excludeUndoubtedLinks,
     );
   }
 }

--- a/src/app/search/simple/search-simple.component.html
+++ b/src/app/search/simple/search-simple.component.html
@@ -201,6 +201,15 @@
               >
               <span>Inkluder livsforløb, der indeholder usikre links</span>
             </label>
+            <label class="lls-search-options__checkbox-container">
+              <input
+                [(ngModel)]="includeUndoubtedLinks"
+                type="checkbox"
+                class="lls-search-options__checkbox"
+                name="includeUndoubtedLinks"
+              >
+              <span>Inkluder livsforløb, der indeholder sikre links</span>
+            </label>
           </div>
 
           <button

--- a/src/app/search/simple/search-simple.component.ts
+++ b/src/app/search/simple/search-simple.component.ts
@@ -22,6 +22,7 @@ export class SimpleSearchComponent implements OnInit {
   // Advanced search
   modeFuzzy = false;
   includeDubiousLinks = true;
+  includeUndoubtedLinks = true;
   searchFieldPlaceholders = searchFieldPlaceholders;
   searchFieldLabels = searchFieldLabels;
 
@@ -143,7 +144,8 @@ export class SimpleSearchComponent implements OnInit {
         index: this.computedIndex,
         mode: this.modeFuzzy ? "fuzzy" : "default",
         excludeDubiousLinks: this.includeDubiousLinks ? null : "true",
-      }
+        excludeUndoubtedLinks: this.includeUndoubtedLinks ? null : "true",
+      },
     });
   }
 


### PR DESCRIPTION
- Added ability to exclude safe links (with duplicates = 1)
- Fixed bug in source linking graph that would show links as bad even if they had duplicates = 1 (because 1 is truthy)