### PR TITLE
Adjust max number of pages shown

### DIFF
--- a/src/app/search-result-list/search-result-list.component.ts
+++ b/src/app/search-result-list/search-result-list.component.ts
@@ -250,7 +250,7 @@ export class SearchResultListComponent implements OnInit {
     let totalPages = Math.ceil(this.searchResult.totalHits / size);
 
     // Adjust total pages so we max include 10.000 items (limit in elasticsearch)
-    totalPages = Math.min(totalPages, Math.ceil(10000 / size));
+    totalPages = Math.min(totalPages, Math.ceil(1000 / size));
 
     // page defaults to 1
     let page = Number(queryParamMap.get('pg'));


### PR DESCRIPTION
We should allow at most 1000 items to be shown, as thats the limit from elasticsearch