### PR TITLE
Fix some inconsistent naming of the filters on a search history entry

### DIFF
--- a/src/app/search-history.ts
+++ b/src/app/search-history.ts
@@ -149,7 +149,7 @@ export function getLatestSearchQuery() {
     if(entry.filters) {
       queryParams = {
         ...queryParams,
-        filters: entry.filters
+        sourceFilter: entry.filters
           .map((filter) => Object.values(filter).join('_'))
           .join(",")
       };

--- a/src/app/search-history/component.ts
+++ b/src/app/search-history/component.ts
@@ -48,10 +48,10 @@ export class SearchHistoryComponent implements OnInit {
       queryParams = { ...queryParams, ...entry.sort };
     }
 
-    if(entry.sourceFilter) {
+    if(entry.filters) {
       queryParams = {
         ...queryParams,
-        sourceFilter: entry.sourceFilter
+        sourceFilter: entry.filters
           .map((filter) => Object.values(filter).join('_'))
           .join(",")
       };


### PR DESCRIPTION
At some point we must have renamed from sourceFilter to filters (whcih is more accurate!) but we still use sourceFilter in many other places in the code... defs a cleanup point at some point...