### PR TITLE
Add ratingScoreStatus to links

### DIFF
--- a/src/app/life-course/source-linking-graph.component.html
+++ b/src/app/life-course/source-linking-graph.component.html
@@ -80,7 +80,7 @@
             </div>
         </div>
         <p *ngIf="link.ratingScoreStatus" class="u-mt-2">
-            Dette linkt har fået tilstrækkelig feedback. Og er dermed sandsynligvis {{ link.ratingScoreStatus }}.
+            Dette link har fået tilstrækkelig feedback og er dermed sandsynligvis {{ link.ratingScoreStatus }}.
             Vi har ikke brug for yderligere feedback. Linket vil blive opdateret i næste version.
         </p>
     </div>

--- a/src/app/life-course/source-linking-graph.component.html
+++ b/src/app/life-course/source-linking-graph.component.html
@@ -68,14 +68,20 @@
                 Læs mere om metoder til linkning
             </a>
         </div>
-        <div class="u-mt-2 mb-2 u-bold">
-            Er linket troværdigt?
+        <div *ngIf="!link.ratingScoreStatus">
+            <div class="u-mt-2 mb-2 u-bold">
+                Er linket troværdigt?
+            </div>
+            <button class="lls-btn lls-btn--small lls-btn--blue" (click)="openLinkRating.emit(link.id)">
+                Giv feedback
+            </button>
+            <div class="u-mt-2">
+                {{ link.totalRatings }} {{ link.totalRatings != 1 ? "personer" : "person" }} har givet feedback på dette link
+            </div>
         </div>
-        <button class="lls-btn lls-btn--small lls-btn--blue" (click)="openLinkRating.emit(link.id)">
-            Giv feedback
-        </button>
-        <div class="u-mt-2">
-            {{ link.totalRatings }} {{ link.totalRatings != 1 ? "personer" : "person" }} har givet feedback på dette link
-        </div>
+        <p *ngIf="link.ratingScoreStatus" class="u-mt-2">
+            Dette linkt har fået tilstrækkelig feedback. Og er dermed sandsynligvis {{ link.ratingScoreStatus }}.
+            Vi har ikke brug for yderligere feedback. Linket vil blive opdateret i næste version.
+        </p>
     </div>
 </div>

--- a/src/app/life-course/source-linking-graph.component.ts
+++ b/src/app/life-course/source-linking-graph.component.ts
@@ -15,8 +15,10 @@ interface DrawableLink {
   ratingScoreStatus: string,
 };
 
-const postitiveRatingKeyFromAPI: string = "Ja, det er troværdigt"
-const negativeRatingKeyFromAPI: string = "Nej, det er ikke troværdigt"
+enum LinkRating {
+  Positive = "Ja, det er troværdigt",
+  Negative = "Nej, det er ikke troværdigt",
+}
 
 @Component({
   selector: 'app-source-linking-graph',
@@ -139,12 +141,11 @@ export class SourceLinkingGraphComponent implements OnInit {
     this.drawableLinks = this.calculateDrawableLinks();
     this.drawableLinks.forEach((link) => {
       this.ratingService.getLinkRatingStats(link.id).subscribe(({ headingRatings }) => {
-        const postitiveRatings = headingRatings[postitiveRatingKeyFromAPI] || 0;
-        const negativeRatings = headingRatings[negativeRatingKeyFromAPI] || 0;
+        const postitiveRatings = headingRatings[LinkRating.Positive] || 0;
+        const negativeRatings = headingRatings[LinkRating.Negative] || 0;
         const ratingScore = postitiveRatings - negativeRatings;
         link.ratingScoreStatus = this.getRatingScoreText(ratingScore);
       });
-
     })
   }
 

--- a/src/app/life-course/source-linking-graph.component.ts
+++ b/src/app/life-course/source-linking-graph.component.ts
@@ -137,18 +137,18 @@ export class SourceLinkingGraphComponent implements OnInit {
 
   ngOnInit(): void {
     this.drawableLinks = this.calculateDrawableLinks();
-    this.drawableLinks.forEach(link => {
+    this.drawableLinks.forEach((link) => {
       this.ratingService.getLinkRatingStats(link.id).subscribe(({ headingRatings }) => {
-        const postitiveRatings = headingRatings[postitiveRatingKeyFromAPI] | 0
-        const negativeRatings = headingRatings[negativeRatingKeyFromAPI] | 0
+        const postitiveRatings = headingRatings[postitiveRatingKeyFromAPI] || 0;
+        const negativeRatings = headingRatings[negativeRatingKeyFromAPI] || 0;
         const ratingScore = postitiveRatings - negativeRatings;
-        link.ratingScoreStatus = this.ratingScoreText(ratingScore)
+        link.ratingScoreStatus = this.getRatingScoreText(ratingScore);
       });
 
     })
   }
 
-  ratingScoreText(ratingScore){
+  getRatingScoreText(ratingScore){
     if (ratingScore <= -5) {
       return "ikke troværdigt";
     }


### PR DESCRIPTION
Trello: https://trello.com/c/wD7H6gFz/154-hvis-et-link-har-f%C3%A5et-5-negative-bed%C3%B8mmelser-skal-brugerne-ikke-l%C3%A6ngere-sp%C3%B8rges-om-feedback

### Changes
- Add ratingScoreStatus data to links in `source-linking-graph.component`. 
- Status can be negative or positive, depending on the amount of good/bad ratings.
- We disable rating if a link is rated too bad/good.

### Screenshot:
![Screenshot from 2022-04-25 16-40-07](https://user-images.githubusercontent.com/8166831/165112394-f08c28ba-2280-44da-b67a-7b5c03f826e9.png)