### PR TITLE
Update input markup to have explicit labels with aria-labledby to be WCAG compliant

### DIFF
--- a/src/app/search-result-list/search-result-list.component.html
+++ b/src/app/search-result-list/search-result-list.component.html
@@ -19,7 +19,7 @@
             <div class="lls-columns-12 lls-columns-6--md lls-columns-8--lg lls-columns-9--xl">
                 <div class="lls-row lls-row--align-bottom">
                     <div class="lls-results-header__field-label lls-columns-12 lls-columns-6--md lls-columns-4--lg lls-columns-2--xl" *ngFor="let searchTerm of searchTerms; index as i;">
-                        <span class="lls-results-header__field-label-text">{{ searchFieldLabels[searchTerm.field] }}</span>
+                        <span [id]="'search-' + searchTerm.field" class="lls-results-header__field-label-text">{{ searchFieldLabels[searchTerm.field] }}</span>
                         <div class="lls-input-group" *ngIf="searchTerm.field !== 'gender'">
                             <input
                                 [(ngModel)]="searchTerm.value"
@@ -28,6 +28,7 @@
                                 class="lls-input-field"
                                 [name]="'searchterm-value-' + i"
                                 [attr.data-search-term]="searchTerm.field"
+                                [attr.aria-labelledby]="'search-' + searchTerm.field"
                             />
                             <button
                                 type="button"
@@ -50,6 +51,7 @@
                                 [name]="'searchterm-value-' + i"
                                 [attr.data-search-term]="searchTerm.field"
                                 [(ngModel)]="searchTerm.value"
+                                [attr.aria-labelledby]="'search-' + searchTerm.field"
                             ></lls-dropdown>
                             <button
                                 type="button"

--- a/src/app/search/simple/search-simple.component.html
+++ b/src/app/search/simple/search-simple.component.html
@@ -69,7 +69,7 @@
         <div class="lls-row">
         <div *ngFor="let searchTerm of hardcodedSearchTerms; index as i;" class="lls-columns-12 lls-columns-6--md">
           <div class="lls-input-entry">
-            <span class="lls-input-label">{{ searchFieldLabels[searchTerm.field] }}</span>
+            <span [id]="'search-' + searchTerm.field" class="lls-input-label">{{ searchFieldLabels[searchTerm.field] }}</span>
             <div class="lls-input-group" *ngIf="searchTerm.field !== 'gender'">
               <input
                 type="text"
@@ -78,6 +78,7 @@
                 [(ngModel)]="searchTerm.value"
                 [name]="'searchterm-value-' + i"
                 [attr.data-search-term]="searchTerm.field"
+                [attr.aria-labelledby]="'search-' + searchTerm.field"
               />
               <button
                 type="button"
@@ -94,7 +95,7 @@
           </div>
         </div>
         <div *ngFor="let searchTerm of addedSearchTerms; index as i;" class="lls-input-entry lls-columns-12">
-          <span class="lls-input-label">{{ searchFieldLabels[searchTerm.field] }}</span>
+          <span [id]="'search-' + searchTerm.field" class="lls-input-label">{{ searchFieldLabels[searchTerm.field] }}</span>
           <div class="lls-input-group" *ngIf="searchTerm.field !== 'gender'">
             <input
               type="text"
@@ -103,6 +104,7 @@
               [(ngModel)]="searchTerm.value"
               [name]="'searchterm-value-' + i"
               [attr.data-search-term]="searchTerm.field"
+              [attr.aria-labelledby]="'search-' + searchTerm.field"
             />
             <button
               type="button"
@@ -125,6 +127,7 @@
               [name]="'searchterm-value-' + i"
               [attr.data-search-term]="searchTerm.field"
               [(ngModel)]="searchTerm.value"
+              [attr.aria-labelledby]="'search-' + searchTerm.field"
             ></lls-dropdown>
             <button
               type="button"

--- a/src/app/user-profile/user-profile.component.html
+++ b/src/app/user-profile/user-profile.component.html
@@ -135,6 +135,7 @@
                   [(ngModel)]="newUsername"
                   name="new-nickname"
                   [disabled]="saving"
+                  aria-label="Indtast nyt brugernavn"
                 />
               </div>
             </td>
@@ -151,6 +152,7 @@
                   [(ngModel)]="newEmail"
                   name="new-email"
                   [disabled]="saving"
+                  aria-label="Indtast ny email"
                 />
               </div>
             </td>

--- a/src/lls-login-button.js
+++ b/src/lls-login-button.js
@@ -15,7 +15,7 @@
   let addedMenuItems = [];
   const addItem = (href, text) => {
     const loginMenuLink = document.createElement('li');
-    loginMenuLink.id = 'menu-item-9999-da';
+    loginMenuLink.id = `menu-item-9999-da-${href}`;
     loginMenuLink.classList.add('menu-item', 'menu-item-type-custom', 'menu-item-object-custom', 'menu-item-9999-da');
     loginMenuLink.innerHTML = `<a href="${pathPrefix + href}" tabindex="0">${text}</a>`;
 


### PR DESCRIPTION
Trello: https://trello.com/c/D35LGcNn/361-wcag-krav-inpult-felter-skal-have-beskrivelse


Did some updating to the markup to fix this issue:
> Input field has no description
 1.3.1 Info and Relationships
Input fields should always have a description that is explicitly associated with the field to make sure that users of assistive technologies will also know what the field is for.
If the input field has a visible description indicating the purpose of the field, this description should be explicitly associated to the input field either as a HTML label or using the WAI-ARIA attribute 'aria-labelledby'.