### PR TITLE
Life course info fix

### DIFF
--- a/src/app/life-course/life-course.component.html
+++ b/src/app/life-course/life-course.component.html
@@ -41,22 +41,18 @@
                 <p class="u-text-capitalize u-mr-2">
                     <span class="u-text-grey--light u-mr-2">Fødested</span> {{ birthPlace }}
                 </p>
-                <ng-container *ngIf="birthYear">
-                    <p class="u-align-icon">
+                    <p class="u-align-icon" *ngIf="birthYear">
                         <svg class="lls-icon lls-icon--filled lls-icon--small lls-icon--left">
                             <use [attr.href]="featherSpriteUrl + '#star'"></use>
                         </svg>
                         {{ birthYear }}
                     </p>
-                </ng-container>
-                <ng-container *ngIf="deathYear">
-                    <p class="u-align-icon">
+                    <p class="u-align-icon" *ngIf="deathYear">
                         <svg class="lls-icon lls-icon--filled lls-icon--small lls-icon--left">
                             <use [attr.href]="featherSpriteUrl + '#ll-dead'"></use>
                         </svg>
                         {{ deathYear }}
                     </p>
-                </ng-container>
             </div>
         </div>
     </section>

--- a/src/app/life-course/life-course.component.html
+++ b/src/app/life-course/life-course.component.html
@@ -41,18 +41,18 @@
                 <p class="u-text-capitalize u-mr-2">
                     <span class="u-text-grey--light u-mr-2">Fødested</span> {{ birthPlace }}
                 </p>
-                    <p class="u-align-icon" *ngIf="birthYear">
-                        <svg class="lls-icon lls-icon--filled lls-icon--small lls-icon--left">
-                            <use [attr.href]="featherSpriteUrl + '#star'"></use>
-                        </svg>
-                        {{ birthYear }}
-                    </p>
-                    <p class="u-align-icon" *ngIf="deathYear">
-                        <svg class="lls-icon lls-icon--filled lls-icon--small lls-icon--left">
-                            <use [attr.href]="featherSpriteUrl + '#ll-dead'"></use>
-                        </svg>
-                        {{ deathYear }}
-                    </p>
+                <p class="u-align-icon" *ngIf="birthYear">
+                    <svg class="lls-icon lls-icon--filled lls-icon--small lls-icon--left">
+                        <use [attr.href]="featherSpriteUrl + '#star'"></use>
+                    </svg>
+                    {{ birthYear }}
+                </p>
+                <p class="u-align-icon" *ngIf="deathYear">
+                    <svg class="lls-icon lls-icon--filled lls-icon--small lls-icon--left">
+                        <use [attr.href]="featherSpriteUrl + '#ll-dead'"></use>
+                    </svg>
+                    {{ deathYear }}
+                </p>
             </div>
         </div>
     </section>

--- a/src/app/life-course/life-course.component.ts
+++ b/src/app/life-course/life-course.component.ts
@@ -43,13 +43,11 @@ export class LifeCourseComponent implements OnInit {
   }
 
   get birthPlace() {
-    const firstPaWithBirthPlace = this.pas.find((pa) => pa.birthplace_display);
-    return firstPaWithBirthPlace ? firstPaWithBirthPlace.birthplace_display : "";
+    return this.latestPersonAppearance.birthplace_display || "";
   }
 
   get birthYear() {
-    const firstPaWithBirthYear = this.pas.find((pa) => pa.birthyear_display);
-    return firstPaWithBirthYear ? firstPaWithBirthYear.birthyear_display : "";
+    return this.latestPersonAppearance.birthyear_display || "";
   }
 
   get deathYear() {


### PR DESCRIPTION
c.f. "Visning af oplysninger om livsforløb" på Trello

Dette retter til så der kun bruges information fra seneste person appearance på et livsforløb til alle felter der hives op i toppen af siden.