### PR TITLE
Deduplicate login button

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,8 +1,14 @@
 const branch = process.env.TRAVIS_BRANCH;
+
 process.env.PATH_PREFIX = {
     'staging': '/find-livsforloeb-testversion',
     'master': '/soeg',
 }[branch] || '';
+
+process.env.EXCLUDE_PATHS = {
+    'staging': /^.(?!find-livsforloeb-testversion)/, // ?! is a negative lookahead: exclude IF NOT followed by staging url
+    'master': /\/find-livsforloeb-testversion/, // exclude only test version page
+}[branch] || [];
 
 const config = {
     plugins: ['transform-inline-environment-variables'],

--- a/src/lls-login-button.js
+++ b/src/lls-login-button.js
@@ -1,10 +1,16 @@
 (function() {
   let pathPrefix = '';
+  let excludePaths = [];
   try {
     pathPrefix = process.env.PATH_PREFIX;
+    excludePaths = process.env.EXCLUDE_PATHS;
   }
   catch(error) {
-    // No path prefix
+    // Failed to load env vars, that's ok.
+  }
+
+  if(excludePaths.some((regex) => regex.test(window.location.pathname))) {
+    return;
   }
 
   const loggedIn = localStorage.getItem("lls__isLoggedIn");


### PR DESCRIPTION
When building prod or staging disable the login button script on certain pages to avoid duplicate login button on test page