### PR TITLE
Fix birthPlace and birthYear in life course item components too

### DIFF
--- a/src/app/life-course/life-course-item.component.ts
+++ b/src/app/life-course/life-course-item.component.ts
@@ -34,13 +34,11 @@ export class LifeCourseItemComponent implements OnChanges {
   }
 
   get birthPlace() {
-    const firstPaWithBirthPlace = this.personAppearances.find((pa) => pa.birthplace_display);
-    return firstPaWithBirthPlace ? firstPaWithBirthPlace.birthplace_display : "";
+    return this.latestPersonAppearance.birthplace_display || "";
   }
 
   get birthYear() {
-    const firstPaWithBirthYear = this.personAppearances.find((pa) => pa.birthyear_display);
-    return firstPaWithBirthYear ? firstPaWithBirthYear.birthyear_display : "";
+    return this.latestPersonAppearance.birthyear_display || "";
   }
 
   get deathYear() {


### PR DESCRIPTION
Same change as in #319 but fixes it for life course items (as shown in search results) for consistency.