### PR TITLE
Fix user auth on refresh

### DIFF
--- a/src/app/auth/login-completed/component.ts
+++ b/src/app/auth/login-completed/component.ts
@@ -38,9 +38,17 @@ export class LoginCompletedComponent implements OnInit {
       return;
     }
 
+    let queryParams;
+    if(query) {
+      queryParams = getObjectFromQueryString(query);
+
+      // Overwrite path with redirect URI if any, remove from query params set
+      path = queryParams.redirect_uri || path;
+      delete queryParams.redirect_uri;
+    }
+
     localStorage.removeItem('onLoginCompleted');
 
-    let queryParams;
     if(!path) {
       console.warn('missing path on onLoginCompleted');
       this.router.navigate(['']);
@@ -57,14 +65,6 @@ export class LoginCompletedComponent implements OnInit {
       return;
     }
 
-    if(!query) {
-      this.router.navigate([path]);
-      return;
-    }
-
-    queryParams = getObjectFromQueryString(query)
-    this.router.navigate([path], {
-      queryParams,
-    });
+    this.router.navigate([path], { queryParams });
   }
 }

--- a/src/app/user-management/service.ts
+++ b/src/app/user-management/service.ts
@@ -36,7 +36,13 @@ export class UserManagementService {
 
   getUser(): Promise<User> {
     return new Promise((resolve, reject) => this.auth.user$.subscribe({
-      next: resolve,
+      next: (user) => {
+        if(!user && localStorage.getItem('lls__isLoggedIn')) {
+          this.handleLogin();
+          return;
+        }
+        resolve(user);
+      },
       error: reject,
     }));
   }

--- a/src/app/user-management/service.ts
+++ b/src/app/user-management/service.ts
@@ -61,19 +61,18 @@ export class UserManagementService {
 
   handleLogin() {
     const path = this.currentPath();
-    const redirect_uri = UserManagementService.baseUrl;
-    const onLoginCompleted: { path: string, query?: string } = {
-      path,
-    };
+    const onLoginCompleted: { path: string, query?: string } = { path };
 
     if(window.location.search.length > 1) {
       onLoginCompleted.query = window.location.search.substring(1);
     }
+
     localStorage.setItem('onLoginCompleted', JSON.stringify(onLoginCompleted));
+
     this.auth.loginWithRedirect({
-      redirect_uri,
+      redirect_uri: UserManagementService.baseUrl,
       appState: { target: 'login-completed' }
-    })
+    });
   }
 
   handleLogout() {


### PR DESCRIPTION
Fixes error when cookies are disabled where refresh of the page would result in the user being logged in according to the login-buttons in the menu but logged out from the perspective of the SPA.

If we end up in this limbo state, we now send users via Auth0 to login.