### PR TITLE
Tweak Data page header links

### DIFF
--- a/src/app/download-data-link/view.html
+++ b/src/app/download-data-link/view.html
@@ -1,7 +1,7 @@
 <app-loading-overlay
   [class]="openModal ? '' : 'u-hide'"
 ></app-loading-overlay>
-<ng-container>
+<ng-container *ngIf="user">
   <a
     *ngIf="user"
     tabindex="0"

--- a/src/app/download-data-link/view.html
+++ b/src/app/download-data-link/view.html
@@ -1,7 +1,7 @@
 <app-loading-overlay
   [class]="openModal ? '' : 'u-hide'"
 ></app-loading-overlay>
-<ng-container *ngIf="user">
+<ng-container>
   <a
     *ngIf="user"
     tabindex="0"

--- a/src/assets/styling/data-page-header.scss
+++ b/src/assets/styling/data-page-header.scss
@@ -35,22 +35,19 @@
   font-size: 1rem;
   font-weight: 400;
   text-align: right;
-  white-space: nowrap;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: end;
+  flex-shrink: 0;
+  gap: 1.125rem;
 
   @media(max-width: $breakpointSm) {
     margin-bottom: 1rem;
-    white-space: normal;
   }
 }
 
 .lls-data-page-header__utility-link {
   white-space: nowrap;
   display: inline-block;
-  margin-right: 1.125rem;
-
-  @media(min-width: $breakpointSm) {
-    &:last-child {
-      margin-right: 0;
-    }
-  }
 }

--- a/src/assets/styling/data-page-header.scss
+++ b/src/assets/styling/data-page-header.scss
@@ -38,7 +38,7 @@
   display: flex;
   flex-wrap: wrap;
   align-items: baseline;
-  justify-content: end;
+  justify-content: flex-end;
   flex-shrink: 0;
   gap: 1.125rem;
 


### PR DESCRIPTION
This approach should be a little more robust, when handling different amounts of links. The flex-wrapping works pretty alright with the 2 to 4 links that we have right now.

I think this section in general should be rethought. Maybe as a more header-like component, that can collapse or have drop-downs on mobile. 

### Caps:
Production:
![image](https://user-images.githubusercontent.com/8166831/204287808-896c7fef-56df-4889-b46c-ec05ce10139d.png)

After tweak:
![image](https://user-images.githubusercontent.com/8166831/204288886-9f49ad0d-aa1e-47e7-8252-8e20ca03ca18.png)

