### PR TITLE
Make the table data more readable on small devices

### DIFF
--- a/src/assets/styling/data-page-data-section.scss
+++ b/src/assets/styling/data-page-data-section.scss
@@ -19,14 +19,16 @@
   td {
     padding: 0.25rem 0;
   }
-  
+
   tr {
     border-bottom: 1px solid $grey-border;
     grid-column: span 1;
     grid-row: span 1;
+    display: flex;
+    flex-direction: column;
 
-    @media (min-width: $breakpointMd) {
-      display: flex;
+    @media (min-width: $breakpointSm) {
+      flex-direction: row;
     }
 
     &[data-first-in-column] {
@@ -39,7 +41,7 @@
       display: block;
     }
   }
-  
+
   th {
     font-weight: 400;
     padding-right: 1rem;


### PR DESCRIPTION
Make the table data more readable, and less prone to overflow errors on small devices

### Production:
![image](https://user-images.githubusercontent.com/8166831/204293242-34320037-e2f1-43a9-8c3e-e6aecd45bbfa.png)

### After tweak:
![image](https://user-images.githubusercontent.com/8166831/204293292-560a3e3e-efcf-4d98-a78b-4f7298861d7d.png)
