### PR TITLE
Restrict download if query params is not 2 or more.

### DIFF
--- a/src/app/data/download.service.ts
+++ b/src/app/data/download.service.ts
@@ -15,7 +15,7 @@ const sourceTypeApiMap = {
 export class DownloadService {
   constructor(private http: HttpClient) {}
 
-  sendDownloadRequest(fileType: any, sourceType: string, sourceId?: string, query?: string) {
+  sendDownloadRequest(fileType: any, sourceType: string, sourceId?: string, query?: object) {
     const url = `${environment.apiUrl}/${sourceTypeApiMap[sourceType]}/${sourceId}/download.${fileType}`
     return this.http.post(url, "", {
       observe: "response",

--- a/src/app/download-data-link/component.ts
+++ b/src/app/download-data-link/component.ts
@@ -7,7 +7,7 @@ import { Buffer } from 'buffer';
 interface inputData {
   type: string,
   id?: string,
-  query?: string,
+  query?: object,
   estimated_results: number
 }
 
@@ -28,7 +28,6 @@ export class DownloadDataLink implements OnInit {
   openModal: boolean = false;
   sourceDownloadLimit: number = 500;
   minimumSearchQueryFields: number = 2;
-  searchQueryFields: number = 2; // PLACEHOLDER. TODO: Should get from search data.
   user;
   downloadFormats: Array<object> = [
     {
@@ -51,8 +50,10 @@ export class DownloadDataLink implements OnInit {
     if (this.data.estimated_results > this.sourceDownloadLimit) {
       return false;
     }
-    if (this.searchQueryFields < this.minimumSearchQueryFields) {
-      return false;
+    if (this.data.query) {
+      if (this.queryParamLength(this.data.query) < this.minimumSearchQueryFields) {
+        return false;
+      }
     }
     return true;
   }
@@ -71,6 +72,16 @@ export class DownloadDataLink implements OnInit {
       return false;
     }
     return true;
+  }
+
+  queryParamLength(queryParams) {
+    let filteredObj = queryParams
+    Object.keys(filteredObj).forEach(key => {
+      if (!filteredObj[key]) {
+        delete filteredObj[key];
+      }
+    });
+    return Object.keys(filteredObj).length;
   }
 
   closeOnEsc() {

--- a/src/app/download-data-link/component.ts
+++ b/src/app/download-data-link/component.ts
@@ -75,13 +75,7 @@ export class DownloadDataLink implements OnInit {
   }
 
   queryParamLength(queryParams) {
-    let filteredObj = queryParams
-    Object.keys(filteredObj).forEach(key => {
-      if (!filteredObj[key]) {
-        delete filteredObj[key];
-      }
-    });
-    return Object.keys(filteredObj).length;
+    return Object.values(queryParams).filter((val) => val).length;
   }
 
   closeOnEsc() {


### PR DESCRIPTION
I saw that we have all the data needed in the query param data.

Last restriction we needed on the download option.

Trello: https://trello.com/c/VS9OKLwW/370-som-arkivar-vil-jeg-gerne-begr%C3%A6nse-hvilke-data-der-kan-downloades