### PR TITLE
Fix bug: Dynamic class cannot be false

### DIFF
--- a/src/app/person-appearance/source-data.component.html
+++ b/src/app/person-appearance/source-data.component.html
@@ -24,7 +24,7 @@
 
     <div
         class="lls-card__actions"
-        [class]="isBurialProtocol() && 'lls-card__actions--first-element'"
+        [class]="isBurialProtocol() ? 'lls-card__actions--first-element' : ''"
     >
         <a
             class="lls-btn"


### PR DESCRIPTION
Use shorthand `if/else` instead of `&&`.

Angular threw errors when returning `false` in the `[class]`.